### PR TITLE
feat:排班表编辑器干员筛选功能补充和调整

### DIFF
--- a/src/static/json/i18n/Language_Dictionary_Schedule.json
+++ b/src/static/json/i18n/Language_Dictionary_Schedule.json
@@ -307,7 +307,7 @@
       "en": "Order Limit"
     },
     "BetterOrders": {
-      "cn": "高品质",
+      "cn": "高品质订单",
       "en": "Better Orders"
     },
     "ProductionEfficiency": {
@@ -319,8 +319,8 @@
       "en": "Morale Drain/Restore"
     },
     "Special": {
-      "cn": "特殊技能",
-      "en": "Special"
+      "cn": "特殊组合",
+      "en": "Special Combo"
     },
     "PerceptionInformation": {
       "cn": "感知信息",
@@ -334,17 +334,45 @@
       "cn": "赤金生产线",
       "en": "Gold Production Line"
     },
-    "PinusSylvestrisKnightsTeam": {
-      "cn": "红松骑士团",
-      "en": "Pinus Sylvestris Knights Team"
+    "KnightsTeam": {
+      "cn": "骑士",
+      "en": "Knights Team"
     },
     "AutomationTeam": {
       "cn": "自动化",
       "en": "Automation Team"
     },
+    "StandardizationTeam": {
+      "cn": "标准化",
+      "en": "Standardization Team"
+    },
     "RhineTechTeam": {
       "cn": "莱茵科技",
       "en": "Rhine Tech Team"
+    },
+    "RhineLabTeam": {
+      "cn": "莱茵生命",
+      "en": "Rhine Lab Team"
+    },
+    "AbyssalHuntersTeam": {
+      "cn": "深海猎人",
+      "en": "Abyssal Hunters Team"
+    },
+    "BlacksteelTeam": {
+      "cn": "黑钢国际",
+      "en": "Blacksteel Team"
+    },
+    "GlasgowTeam": {
+      "cn": "格拉斯哥帮",
+      "en": "Glasgow Team"
+    },
+    "KarianTradeTeam": {
+      "cn": "咯兰贸易",
+      "en": "Karian Trade Team"
+    },
+    "TeamRainbowTeam": {
+      "cn": "彩虹小队",
+      "en": "Team Rainbow Team"
     }
   }
 }

--- a/src/utils/buildingSkillFilter.js
+++ b/src/utils/buildingSkillFilter.js
@@ -97,6 +97,18 @@ const operatorFilterConditionTable = {
                 func: (operator) => {
                     return operator.roomType === 'manufacture' && operator.description.indexOf('仓库容量上限') > -1
                 }
+            },
+            {
+                label: "buildSkillFilter.StandardizationTeam",
+                func: (operator) => {
+                    operator.buffName.indexOf('标准化') > -1 && operator.description.indexOf('标准化') > -1
+                }
+            },
+            {
+                label: "buildSkillFilter.RhineTechTeam",
+                func: (operator) => {
+                    operator.buffName.indexOf('莱茵科技') > -1
+                }
             }
         ]
     },
@@ -147,6 +159,12 @@ const operatorFilterConditionTable = {
                 func: (operator) => {
                     return operator.roomType === 'control' && operator.description.indexOf('心情') > -1
                 }
+            },
+            {
+                label: "buildSkillFilter.TeamRainbowTeam",
+                func: (operator) => {
+                    operator.buffName.indexOf('彩虹小队') > -1
+                }
             }
         ]
     },
@@ -174,7 +192,7 @@ const operatorFilterConditionTable = {
                 }
             },
             {
-                label: "buildSkillFilter.PinusSylvestrisKnightsTeam",
+                label: "buildSkillFilter.KnightsTeam",
                 func: (operator) => {
                     return operator.buffName.indexOf('红松') > -1 || Knight.includes(operator.name)
                 }
@@ -186,9 +204,33 @@ const operatorFilterConditionTable = {
                 }
             },
             {
-                label: "buildSkillFilter.RhineTechTeam",
+                label: "buildSkillFilter.RhineLabTeam",
                 func: (operator) => {
-                    return Rhine.includes(operator.name)
+                    return RhineLab.includes(operator.name)
+                }
+            },
+            {
+                label: "buildSkillFilter.AbyssalHuntersTeam",
+                func: (operator) => {
+                    return AbyssalHunters.includes(operator.name)
+                }
+            },
+            {
+                label: "buildSkillFilter.BlacksteelTeam",
+                func: (operator) => {
+                    return Blacksteel.includes(operator.name)
+                }
+            },
+            {
+                label: "buildSkillFilter.GlasgowTeam",
+                func: (operator) => {
+                    return Glasgow.includes(operator.name)
+                }
+            },
+            {
+                label: "buildSkillFilter.KarianTradeTeam",
+                func: (operator) => {
+                    return KarianTrade.includes(operator.name)
                 }
             }
         ]
@@ -198,8 +240,12 @@ const operatorFilterConditionTable = {
 // Official english name is "Rosmontis"
 const RosmontisUniverse = ['琴柳']
 const GoldProductionLine = ['桃金娘','杜林','褐果','至简']
-const Knight = ['砾','薇薇安娜']
-const Automation = ['清流','Lancet-2']
-const Rhine = ['淬羽赫默','多萝西','星源','赫默','白面鸮']
+const Knight = ['砾','薇薇安娜','正义骑士号']
+const Automation = ['清流','承曦格雷伊','Lancet-2']
+const RhineLab = ['赫默','伊芙利特','塞雷娅','白面鸮','梅尔','麦哲伦','多萝西','星源','缪尔赛思']
+const AbyssalHunters = ['歌蕾蒂娅','斯卡蒂','幽灵鲨','安哲拉','乌尔比安']
+const Blacksteel = ['雷蛇','芙兰卡','杰西卡','香草','杏仁','涤火杰西卡']
+const Glasgow = ['推进之王','摩根','达格达','因陀罗','戴菲恩']
+const KarianTrade = ['银灰','灵知','初雪','崖心','角峰','讯使','耶拉','极光','锏']
 
 export {operatorFilterConditionTable}


### PR DESCRIPTION
- 调整分类名称，“特殊技能”改为“特殊组合”，我的想法是这里应该特指跨设施的基建技能组合

- “特殊组合”分类下的“莱茵科技”，因为全部都属于制造站技能（不跨设施），故改为放在制造站分类下，且干员列表改为直接从技能名称索引

- 调整分类名称，“红松骑士团”改为“骑士”，因为薇薇安娜实装后这组人已经不局限于红松骑士团的人，这样更准确一点

- 制造站分类下新增“标准化”

- 控制中枢分类下新增“彩虹小队”

- 特殊组合分类下新增“莱茵生命”、“深海猎人”、“黑钢国际”、“格拉斯哥帮”、“咯兰贸易”等，这些应该没办法从技能名称或说明里索引吧，于是都是在下面的追加干员列表里手写的

- 已有追加干员列表中补充其他相关或可能会绑定使用的干员

- 对应翻译补充和个别调整

基本上是比葫芦画瓢写的，虽然自己检查过了，但没准还遗漏了东西，麻烦再检查一下（