### PR TITLE
feat(练度调查结果): 表格首行冻结吸附显示

### DIFF
--- a/src/assets/css/survey/rank.css
+++ b/src/assets/css/survey/rank.css
@@ -41,6 +41,16 @@
     margin:auto;
 }
 
+#rank_table {
+    height: calc(100vh - 186px);
+    overflow-y: auto;
+}
+
+.rank_table > thead {
+    position: sticky;
+    top: 0;
+    background-color: white;
+}
 .rank_table_tr td{
     border-bottom: 1px #9d9d9d solid;
 }

--- a/src/pages/survey/rank.page.vue
+++ b/src/pages/survey/rank.page.vue
@@ -278,6 +278,7 @@ onMounted(() => {
 
     <div id="rank_table">
       <table class="rank_table">
+        <thead>
         <tr>
           <td>
             <div class="rank_table_title" style="width: 220px">代号</div>
@@ -359,8 +360,9 @@ onMounted(() => {
             </div>
           </td>
         </tr>
+      </thead>
 
-
+      <tbody>
         <tr v-for="(result, index) in operatorsStatisticsList" :key="index" v-show="result.show"
             class="rank_table_tr">
           <td class="rank_table_1 rank_table_text">
@@ -429,6 +431,7 @@ onMounted(() => {
             <!--            <div>三级：{{ getPercentage(getSurveyResult(result.modY, 'rank3'), 1) }}</div>-->
           </td>
         </tr>
+      </tbody>
       </table>
     </div>
   </div>


### PR DESCRIPTION
如下视频所示，防止用户滚动到表格下半部分时忘记各列含义
https://github.com/Arknights-yituliu/frontend-v2-plus/assets/32192232/bc26fc5c-e6f3-4a28-92c6-c6b8e64fccc2

