### PR TITLE
fix:基建排班表技能筛选typo

### DIFF
--- a/src/utils/buildingSkillFilter.js
+++ b/src/utils/buildingSkillFilter.js
@@ -101,13 +101,13 @@ const operatorFilterConditionTable = {
             {
                 label: "buildSkillFilter.StandardizationTeam",
                 func: (operator) => {
-                    operator.buffName.indexOf('标准化') > -1 && operator.description.indexOf('标准化') > -1
+                    return operator.buffName.indexOf('标准化') > -1 && operator.description.indexOf('标准化') > -1
                 }
             },
             {
                 label: "buildSkillFilter.RhineTechTeam",
                 func: (operator) => {
-                    operator.buffName.indexOf('莱茵科技') > -1
+                    return operator.buffName.indexOf('莱茵科技') > -1
                 }
             }
         ]
@@ -163,7 +163,7 @@ const operatorFilterConditionTable = {
             {
                 label: "buildSkillFilter.TeamRainbowTeam",
                 func: (operator) => {
-                    operator.buffName.indexOf('彩虹小队') > -1
+                    return operator.buffName.indexOf('彩虹小队') > -1
                 }
             }
         ]


### PR DESCRIPTION
离谱的手滑……

复制粘贴居然把 `return` 弄丢了。实在是不好意思（