### PR TITLE
关于网页端跳转bug

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,32 +29,6 @@ import {useRoute} from "vue-router";
 import {routeMap} from "/src/router/routes";
 import ComponentsContainer from "/src/components/ComponentsContainer.vue";
 
-
-//sail 修改标记
-  
-  
-import { onMounted, watch } from 'vue'
-import { useRoute } from 'vue-router'
-
-const route = useRoute()
-
-const scrollToHash = () => {
-  const hash = route.hash?.replace('#', '')
-  if (hash) {
-    setTimeout(() => {
-      const el = document.getElementById(hash)
-      if (el) {
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-      }
-    }, 100)
-  }
-}
-
-onMounted(scrollToHash)
-watch(() => route.hash, scrollToHash)
-
-
-//sail修改标记
   
 
 const themeOverrides = {

--- a/src/App.vue
+++ b/src/App.vue
@@ -30,6 +30,33 @@ import {routeMap} from "/src/router/routes";
 import ComponentsContainer from "/src/components/ComponentsContainer.vue";
 
 
+//sail 修改标记
+  
+  
+import { onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const scrollToHash = () => {
+  const hash = route.hash?.replace('#', '')
+  if (hash) {
+    setTimeout(() => {
+      const el = document.getElementById(hash)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    }, 100)
+  }
+}
+
+onMounted(scrollToHash)
+watch(() => route.hash, scrollToHash)
+
+
+//sail修改标记
+  
+
 const themeOverrides = {
   common: {
     primaryColor: '#1867C0FF',

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -30,7 +30,7 @@ for (const module in LinkedTable) {
         </v-list-item>
       </template>
       <router-link v-for="(child,index) in parent.child" :key="index"
-                   :to="{ path: child.path, hash: child.hash }" :href="child.path" class="router-link">
+                   :to="child.path" :href="child.path" class="router-link">
         <v-list-item color="primary" rounded :value="child.text">
           <div class="navigation-item-content">
             <v-icon :icon="child.icon"></v-icon>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -30,7 +30,7 @@ for (const module in LinkedTable) {
         </v-list-item>
       </template>
       <router-link v-for="(child,index) in parent.child" :key="index"
-                   :to="child.path" :href="child.path" class="router-link">
+                   :to="{ path: child.path, hash: child.hash }" :href="child.path" class="router-link">
         <v-list-item color="primary" rounded :value="child.text">
           <div class="navigation-item-content">
             <v-icon :icon="child.icon"></v-icon>


### PR DESCRIPTION
本人完全不懂前端，为了学校作业通过同学了解了这个项目，捉个小虫。

由于没有调试，所以PR的代码并没有修改，只是加了一个空行。

网页端“参与开发”的子网页下，中间目录以“项目简介”为首的一系列目录标题未能实现其正文跳转功能。

问题所在：
1.  join-development.vue文件下，页面中部的目录项（项目简介、材料规划等）只是 v-list-item，没有包裹 <a href="#xxx">，无法触发跳转。
2. App.vue文件下，默认并不会在 hash 改变后自动滚动，需要手动监听
3. 还有一个warning：id="project" 出现了 重复（被多个标题共用）

解决办法：
1. join-development.vue中间目录这样写
```javascript
  <v-list dense>
  <v-list-item><a href="#project-intro">项目简介</a></v-list-item>
  <v-list-item><a href="#item">材料规划</a></v-list-item>
  <v-list-item><a href="#tools">实用小工具</a></v-list-item>
  <v-list-item><a href="#survey">调查与统计</a></v-list-item>
  <v-list-item><a href="#join-us">参与开发</a></v-list-item>
  <v-list-item><a href="#web-pr">网页PR方式</a></v-list-item>
  <v-list-item><a href="#local-pr">本地PR方式</a></v-list-item>
</v-list>
``` 


2.App.vue加入
import { onMounted, watch } from 'vue'
import { useRoute } from 'vue-router'

const route = useRoute()

const scrollToHash = () => {
  const hash = route.hash?.replace('#', '')
  if (hash) {
    setTimeout(() => {
      const el = document.getElementById(hash)
      if (el) {
        el.scrollIntoView({ behavior: 'smooth', block: 'start' })
      }
    }, 100)
  }
}

onMounted(scrollToHash)
watch(() => route.hash, scrollToHash)

3.更改重复id
```javascript
<!-- 原来 -->
<h1 id="project">项目简介</h1>

<!-- 改成 -->
<h1 id="project-intro">项目简介</h1>
``` 



大部分是通过GPT现学的，若有幼稚愚钝之处，还望包涵！
