### PR TITLE
feat: 自定义非精英材料定价策略、重构物品价值算法

### DIFF
--- a/docs/pages/item-value-algorithm.vue
+++ b/docs/pages/item-value-algorithm.vue
@@ -169,37 +169,37 @@ import ItemImage from "/src/components/sprite/ItemImage.vue";
         </thead>
         <tbody>
           <tr>
-            <td><ItemImage :item-id="30011"/></td>
+            <td><ItemImage item-id="30011"/></td>
             <td>源岩</td>
             <td>26.32%</td>
             <td>1.1471</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="30021"/></td>
+            <td><ItemImage item-id="30021"/></td>
             <td>代糖</td>
             <td>17.54%</td>
             <td>1.6133</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="30031"/></td>
+            <td><ItemImage item-id="30031"/></td>
             <td>酯原料</td>
             <td>17.54%</td>
             <td>1.6133</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="30041"/></td>
+            <td><ItemImage item-id="30041"/></td>
             <td>异铁碎片</td>
             <td>14.04%</td>
             <td>2.0119</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="30051"/></td>
+            <td><ItemImage item-id="30051"/></td>
             <td>双酮</td>
             <td>14.04%</td>
             <td>2.0097</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="30061"/></td>
+            <td><ItemImage item-id="30061"/></td>
             <td>破损装置</td>
             <td>10.53%</td>
             <td>2.6838</td>
@@ -238,91 +238,91 @@ import ItemImage from "/src/components/sprite/ItemImage.vue";
         </thead>
         <tbody>
           <tr>
-            <td><ItemImage :item-id="'4001'"/></td>
+            <td><ItemImage item-id="4001"/></td>
             <td>龙门币</td>
             <td>0.004</td>
             <td>252</td>
             <td>0.907</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'31054'"/></td>
+            <td><ItemImage item-id="31054"/></td>
             <td>切削原液</td>
             <td>79.245</td>
             <td>0.048</td>
             <td>3.813</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'3003'"/></td>
+            <td><ItemImage item-id="3003"/></td>
             <td>赤金</td>
             <td>0.912</td>
             <td>0.1</td>
             <td>0.091</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'31013'"/></td>
+            <td><ItemImage item-id="31013"/></td>
             <td>凝胶</td>
             <td>32</td>
             <td>0.016</td>
             <td>0.502</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30062'"/></td>
+            <td><ItemImage item-id="30062"/></td>
             <td>装置</td>
             <td>9.851</td>
             <td>0.145</td>
             <td>1.431</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30073'"/></td>
+            <td><ItemImage item-id="30073"/></td>
             <td>扭转醇</td>
             <td>1.8</td>
             <td>0.02</td>
             <td>0.037</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'31053'"/></td>
+            <td><ItemImage item-id="31053"/></td>
             <td>化合切削液</td>
             <td>32</td>
             <td>0.47</td>
             <td>15.029</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30012'"/></td>
+            <td><ItemImage item-id="30012"/></td>
             <td>固源岩</td>
             <td>4.851</td>
             <td>0.364</td>
             <td>1.765</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30013'"/></td>
+            <td><ItemImage item-id="30013"/></td>
             <td>固源岩组</td>
             <td>20</td>
             <td>0.026</td>
             <td>0.514</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30063'"/></td>
+            <td><ItemImage item-id="30063"/></td>
             <td>全新装置</td>
             <td>36</td>
             <td>0.012</td>
             <td>0.432</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30011'"/></td>
+            <td><ItemImage item-id="30011"/></td>
             <td>源岩</td>
             <td>1.377</td>
             <td>0.215</td>
             <td>0.297</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'30061'"/></td>
+            <td><ItemImage item-id="30061"/></td>
             <td>破损装置</td>
             <td>3.044</td>
             <td>0.086</td>
             <td>0.26</td>
           </tr>
           <tr>
-            <td><ItemImage :item-id="'31073'"/></td>
+            <td><ItemImage item-id="31073"/></td>
             <td>褐素纤维</td>
             <td>32</td>
             <td>0.016</td>
@@ -486,90 +486,90 @@ import ItemImage from "/src/components/sprite/ItemImage.vue";
       </thead>
       <tbody>
         <tr>
-          <td><ItemImage :item-id="'3213'"/></td>
+          <td><ItemImage item-id="3213"/></td>
           <td>先锋双芯片</td>
           <td>87</td>
-          <td><ItemImage :item-id="'3212'"/></td>
+          <td><ItemImage item-id="3212"/></td>
           <td>先锋芯片组</td>
           <td>25</td>
-          <td><ItemImage :item-id="'3211'"/></td>
+          <td><ItemImage item-id="3211"/></td>
           <td>先锋芯片</td>
           <td>128</td>
         </tr>
         <tr>
-          <td><ItemImage :item-id="'3223'"/></td>
+          <td><ItemImage item-id="3223"/></td>
           <td>近卫双芯片</td>
           <td>190</td>
-          <td><ItemImage :item-id="'3222'"/></td>
+          <td><ItemImage item-id="3222"/></td>
           <td>近卫芯片组</td>
           <td>75</td>
-          <td><ItemImage :item-id="'3221'"/></td>
+          <td><ItemImage item-id="3221"/></td>
           <td>近卫芯片</td>
           <td>290</td>
         </tr>
         <tr>
-          <td><ItemImage :item-id="'3233'"/></td>
+          <td><ItemImage item-id="3233"/></td>
           <td>重装双芯片</td>
           <td>105</td>
-          <td><ItemImage :item-id="'3232'"/></td>
+          <td><ItemImage item-id="3232"/></td>
           <td>重装芯片组</td>
           <td>30</td>
-          <td><ItemImage :item-id="'3231'"/></td>
+          <td><ItemImage item-id="3231"/></td>
           <td>重装芯片</td>
           <td>154</td>
         </tr>
         <tr>
-          <td><ItemImage :item-id="'3243'"/></td>
+          <td><ItemImage item-id="3243"/></td>
           <td>狙击双芯片</td>
           <td>127</td>
-          <td><ItemImage :item-id="'3242'"/></td>
+          <td><ItemImage item-id="3242"/></td>
           <td>狙击芯片组</td>
           <td>50</td>
-          <td><ItemImage :item-id="'3241'"/></td>
+          <td><ItemImage item-id="3241"/></td>
           <td>狙击芯片</td>
           <td>194</td>
         </tr>
         <tr>
-          <td><ItemImage :item-id="'3253'"/></td>
+          <td><ItemImage item-id="3253"/></td>
           <td>术师双芯片</td>
           <td>140</td>
-          <td><ItemImage :item-id="'3252'"/></td>
+          <td><ItemImage item-id="3252"/></td>
           <td>术师芯片组</td>
           <td>30</td>
-          <td><ItemImage :item-id="'3251'"/></td>
+          <td><ItemImage item-id="3251"/></td>
           <td>术师芯片</td>
           <td>198</td>
         </tr>
         <tr>
-          <td><ItemImage :item-id="'3263'"/></td>
+          <td><ItemImage item-id="3263"/></td>
           <td>医疗双芯片</td>
           <td>79</td>
-          <td><ItemImage :item-id="'3262'"/></td>
+          <td><ItemImage item-id="3262"/></td>
           <td>医疗芯片组</td>
           <td>30</td>
-          <td><ItemImage :item-id="'3261'"/></td>
+          <td><ItemImage item-id="3261"/></td>
           <td>医疗芯片</td>
           <td>121</td>
         </tr>
         <tr>
-          <td><ItemImage :item-id="'3273'"/></td>
+          <td><ItemImage item-id="3273"/></td>
           <td>辅助双芯片</td>
           <td>103</td>
-          <td><ItemImage :item-id="'3272'"/></td>
+          <td><ItemImage item-id="3272"/></td>
           <td>辅助芯片组</td>
           <td>20</td>
-          <td><ItemImage :item-id="'3271'"/></td>
+          <td><ItemImage item-id="3271"/></td>
           <td>辅助芯片</td>
           <td>146</td>
         </tr>
         <tr>
-        <td><ItemImage :item-id="'3283'"/></td>
+        <td><ItemImage item-id="3283"/></td>
           <td>特种双芯片</td>
           <td>124</td>
-          <td><ItemImage :item-id="'3282'"/></td>
+          <td><ItemImage item-id="3282"/></td>
           <td>特种芯片组</td>
           <td>35</td>
-          <td><ItemImage :item-id="'3281'"/></td>
+          <td><ItemImage item-id="3281"/></td>
           <td>特种芯片</td>
           <td>181</td>
         </tr>

--- a/src/components/account/StageConfig.vue
+++ b/src/components/account/StageConfig.vue
@@ -60,23 +60,33 @@ const BeastsStage = ref({
   },
 })
 
-const stageConfigPanel = ref(['preset-parameter'])
-
-// 响应式数据
+/**
+ * 物品定价策略
+ */
+const stageConfig = ref({});
+/**
+ * 已打开的物品定价策略设置面板
+ */
+const stageConfigPanel = ref(['preset-parameter']);
+/**
+ * 物品列表
+ */
 const itemList = ref([]);
-
+/**
+ * 显示在 debug 区的文本
+ */
 const debugText = ref('');
 
-
+/**
+ * 重置为默认参数
+ */
 function resetConfig() {
   console.log("重置配置");
   console.log(defaultConfig);
-  stageConfig.value = JSON.parse(JSON.stringify(defaultConfig));  // 重置为默认配置，用 JSON 深拷贝
+  stageConfig.value = parseConfig(stringifyConfig(defaultConfig));  // 重置为默认配置，用 JSON 深拷贝
   forceRefreshItemValue();
 }
 
-// 初始化默认配置
-const stageConfig = ref({});
 
 
 function loadingStageConfig() {

--- a/src/components/account/StageConfig.vue
+++ b/src/components/account/StageConfig.vue
@@ -1,14 +1,28 @@
 <script setup>
-import {onMounted, ref} from "vue";
-import {formatNumber} from "/src/utils/format.js";
+import { nextTick, onMounted, ref, watch } from "vue";
+import { formatNumber } from "/src/utils/format.js";
 import itemCache from "/src/plugins/indexedDB/itemCache.js";
 import ItemImage from "@/components/sprite/ItemImage.vue";
-import {getStageConfig} from "@/utils/user/userConfig.js";
+import {
+  getStageConfig,
+  defaultConfig,
+  parseConfig,
+  stringifyConfig,
+  orundumValueMap,
+  originitePrimeCoefficientMap,
+  kernalHeadhuntingPermitCoefficientMap,
+  lmdCoefficientMap,
+  expCoefficientMap,
+  modUnlockTokenValueMap,
+  recruitmentPermitValueMap,
+  expeditedPlanValueMap,
+  furniturePartValueMap
+} from "@/utils/user/userConfig.js";
 import ActionButton from "@/components/account/ActionButton.vue";
-import ActStoreUnlimitedExchangeItem from '/src/static/json/material/act_store_unlimited_exchange_item.json'
-import PresetParameter from "/src/static/json/material/preset_parameter.json"
-import {createMessage} from "/src/utils/message.js";
-import {stringToNumber} from '/src/utils/stringUtils.js'
+import ActStoreUnlimitedExchangeItem from '/src/static/json/material/act_store_unlimited_exchange_item.json';
+import PresetParameter from "../../static/json/material/preset_parameter.json";
+import { createMessage } from "/src/utils/message.js";
+import { stringToNumber } from '/src/utils/stringUtils.js';
 
 const presetParameter = ref(PresetParameter)
 
@@ -18,14 +32,15 @@ const presetParameter = ref(PresetParameter)
 const numberRegex = /^(0|[1-9]\d*)(\.\d+)?$/;
 
 // 输入规则：校验数字格式和范围
-const inputRules = [
+const numberBetween0And1 = [
   value => numberRegex.test(value) || '仅可输入0.0-1.0间的小数，小数点后位数不限',
   value => (value === 0 || (value != null && value !== '')) || '不能为空',
   value => (value >= 0 && value <= 1) || '仅可输入0.0-1.0间的小数，小数点后位数不限',
 ];
+const numberGe0 = [(value) => parseFloat(value) >= 0 || "值必须大于或等于 0"];
 
 
-//Beasts
+// Beasts
 
 const BeastsStage = ref({
   "1-7": {
@@ -53,34 +68,11 @@ const itemList = ref([]);
 const debugText = ref('');
 
 
-
-
 function resetConfig() {
-  stageConfig.value = {
-    expCoefficient: 0.633,
-    lmdCoefficient: 1,
-    useActivityStage: false,
-    useActivityAverageStage: false,
-    stageBlacklist: [],
-    source: 'penguin',
-    workshopEliteMaterialByProductRate: 0.2,
-    workshopSkillSummaryByProductRate: 0.18,
-    customItem: [
-      {
-        itemId: '30073',
-        itemName: "扭转醇",
-        itemValue: 1.8
-      },
-      {
-        itemId: '30083',
-        itemName: "轻锰矿",
-        itemValue: 2.16
-      }
-    ]
-  }
-
-
-  forceRefreshItemValue()
+  console.log("重置配置");
+  console.log(defaultConfig);
+  stageConfig.value = JSON.parse(JSON.stringify(defaultConfig));  // 重置为默认配置，用 JSON 深拷贝
+  forceRefreshItemValue();
 }
 
 // 初始化默认配置
@@ -88,7 +80,7 @@ const stageConfig = ref({});
 
 
 function loadingStageConfig() {
-// 合并本地配置
+  // 合并本地配置
   stageConfig.value = getStageConfig(); // 合并配置
 
   stageConfig.value.useActivityStage = false
@@ -116,27 +108,157 @@ function loadingStageConfig() {
 
 function choosePresetParameter(presetParameter) {
   const parameters = presetParameter.parameters
-
-
   for (const name in parameters) {
     stageConfig.value[name] = parameters[name];
   }
-
-
   updateStageActive()
-
   createMessage({
     type: 'info',
     text: presetParameter.message,
     duration: 4000
   })
-
-
 }
 
 
+// 输入框 ref
+const orundumValueInput = ref(null);
+const originitePrimeCoefficientInput = ref(null);
+const kernalHeadhuntingPermitCoefficientInput = ref(null);
+const lmdCoefficientInput = ref(null);
+const expCoefficientInput = ref(null);
+const modUnlockTokenValueInput = ref(null);
+const recruitmentPermitValueInput = ref(null);
+const expeditedPlanValueInput = ref(null);
+const furniturePartValueInput = ref(null);
 
-//------------------从这里开始是关卡相关的代码------------------
+// 监听 orundumPricingStrategy 变化
+watch(
+  () => stageConfig.value.orundumPricingStrategy,
+  (orundumPricingStrategy) => {
+    const orundumValue = orundumValueMap[orundumPricingStrategy];
+    if (orundumValue !== undefined) {  // 如果选中预设项
+      stageConfig.value.orundumValue = orundumValue;
+    } else {
+      nextTick(() => orundumValueInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 originitePrimePricingStrategy 变化
+watch(
+  () => stageConfig.value.originitePrimePricingStrategy,
+  (originitePrimePricingStrategy) => {
+    const originitePrimeCoefficient = originitePrimeCoefficientMap[originitePrimePricingStrategy];
+    if (originitePrimeCoefficient !== undefined) {  // 如果选中预设项
+      stageConfig.value.originitePrimeCoefficient = originitePrimeCoefficient;
+    } else {
+      nextTick(() => originitePrimeCoefficientInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 kernalHeadhuntingPermitPricingStrategy 变化
+watch(
+  () => stageConfig.value.kernalHeadhuntingPermitPricingStrategy,
+  (kernalHeadhuntingPermitPricingStrategy) => {
+    const kernalHeadhuntingPermitCoefficient = kernalHeadhuntingPermitCoefficientMap[kernalHeadhuntingPermitPricingStrategy];
+    if (kernalHeadhuntingPermitCoefficient !== undefined) {  // 如果选中预设项
+      stageConfig.value.kernalHeadhuntingPermitCoefficient = kernalHeadhuntingPermitCoefficient;
+    } else {
+      nextTick(() => kernalHeadhuntingPermitCoefficientInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 lmdPricingStrategy 变化
+watch(
+  () => stageConfig.value.lmdPricingStrategy,
+  (lmdPricingStrategy) => {
+    const lmdCoefficient = lmdCoefficientMap[lmdPricingStrategy];
+    if (lmdCoefficient !== undefined) {  // 如果选中预设项
+      stageConfig.value.lmdCoefficient = lmdCoefficient;
+    } else {
+      nextTick(() => lmdCoefficientInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 expPricingStrategy 变化
+watch(
+  () => stageConfig.value.expPricingStrategy,
+  (expPricingStrategy) => {
+    const expCoefficient = expCoefficientMap[expPricingStrategy];
+    if (expCoefficient !== undefined) {  // 如果选中预设项
+      stageConfig.value.expCoefficient = expCoefficient;
+    } else {
+      nextTick(() => expCoefficientInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 modUnlockTokenPricingStrategy 变化
+watch(
+  () => stageConfig.value.modUnlockTokenPricingStrategy,
+  (modUnlockTokenPricingStrategy) => {
+    const modUnlockTokenValue = modUnlockTokenValueMap[modUnlockTokenPricingStrategy];
+    if (modUnlockTokenValue !== undefined) {  // 如果选中预设项
+      stageConfig.value.modUnlockTokenValue = modUnlockTokenValue;
+    } else {
+      nextTick(() => modUnlockTokenValueInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 recruitmentPermitPricingStrategy 变化
+watch(
+  () => stageConfig.value.recruitmentPermitPricingStrategy,
+  (recruitmentPermitPricingStrategy) => {
+    const recruitmentPermitValue = recruitmentPermitValueMap[recruitmentPermitPricingStrategy];
+    if (recruitmentPermitValue !== undefined) {  // 如果选中预设项
+      stageConfig.value.recruitmentPermitValue = recruitmentPermitValue;
+    } else {
+      nextTick(() => recruitmentPermitValueInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 expeditedPlanPricingStrategy 变化
+watch(
+  () => stageConfig.value.expeditedPlanPricingStrategy,
+  (expeditedPlanPricingStrategy) => {
+    const expeditedPlanValue = expeditedPlanValueMap[expeditedPlanPricingStrategy];
+    if (expeditedPlanValue !== undefined) {  // 如果选中预设项
+      stageConfig.value.expeditedPlanValue = expeditedPlanValue;
+    } else {
+      nextTick(() => expeditedPlanValueInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+// 监听 furniturePartPricingStrategy 变化
+watch(
+  () => stageConfig.value.furniturePartPricingStrategy,
+  (furniturePartPricingStrategy) => {
+    const furniturePartValue = furniturePartValueMap[furniturePartPricingStrategy];
+    if (furniturePartValue !== undefined) {  // 如果选中预设项
+      stageConfig.value.furniturePartValue = furniturePartValue;
+    } else {
+      nextTick(() => furniturePartValueInput.value?.focus()); // 如果选中自定义，聚焦到输入框
+    }
+  },
+  { immediate: true },
+);
+
+
+// ------------------从这里开始是关卡相关的代码------------------
 
 
 const stageCollect = ref({
@@ -164,7 +286,7 @@ function getStageCollectByZone() {
     const indexMap = new Map();
 
     for (const stage of response) {
-      const {zoneName, zoneId, stageCode, stageId, stageType, start, end} = stage;
+      const { zoneName, zoneId, stageCode, stageId, stageType, start, end } = stage;
 
       // 过滤掉不需要的阶段类型
       if (!stageTypeMap[stageType]) {
@@ -274,8 +396,18 @@ function useActivityAverageStage() {
 //------------------从这里开始是自定义材料价值相关的代码------------------
 
 const customItemDialog = ref(false);
-const customItem = ref({itemId: '30073', itemName: "扭转醇", itemValue: 1.8});
+const customItem = ref({ itemId: '30073', itemName: "扭转醇", itemValue: 1.8 });
 const actStoreUnlimitedExchangeItem = ref(ActStoreUnlimitedExchangeItem.slice(6, 12))
+
+/**
+ * 判断物品是否为精英材料
+ * 直接使用物品 ID 判断，不一定准确
+ * @param {string} item_id 物品 ID
+ * @return {boolean} 是否为精英材料
+ */
+function isEliteMaterial(item_id) {
+  return /^3[01]\d{3}/.test(item_id);
+}
 
 /**
  * 获取物品列表
@@ -325,7 +457,7 @@ function actStoreUnlimitedExchangeItemActiveClass(active) {
  * @param {{itemId:string,itemName:string,itemValue:number}} item 自定义材料
  */
 function chooseCustomItem(item) {
-  customItem.value = {itemId: item.itemId, itemName: item.itemName, itemValue: item.itemValue};
+  customItem.value = { itemId: item.itemId, itemName: item.itemName, itemValue: item.itemValue };
 }
 
 
@@ -335,7 +467,7 @@ function chooseCustomItem(item) {
 // 添加或更新自定义物品
 function addCustomItem() {
   const existing = stageConfig.value.customItem.find(item => item.itemId === customItem.value.itemId);
-  let {itemId, itemValue, itemName} = customItem.value
+  let { itemId, itemValue, itemName } = customItem.value
   itemValue = stringToNumber(itemValue)
   for (const item of actStoreUnlimitedExchangeItem.value) {
     if (item.itemId === itemId) {
@@ -347,7 +479,7 @@ function addCustomItem() {
   if (existing) {
     existing.itemValue = itemValue; // 更新现有物品
   } else {
-    stageConfig.value.customItem.push({itemId, itemValue, itemName}); // 新增物品
+    stageConfig.value.customItem.push({ itemId, itemValue, itemName }); // 新增物品
   }
   customItemDialog.value = false; // 关闭对话框
 }
@@ -386,7 +518,7 @@ function checkStageConfig() {
 function forceRefreshItemValue() {
   updateStageConfig()
   checkStageConfig(); // 校验配置
-  localStorage.setItem("StageConfig", JSON.stringify(stageConfig.value)); // 保存配置
+  localStorage.setItem("StageConfig", stringifyConfig(stageConfig.value)); // 保存配置
   itemCache.getItemValueCacheByConfig(stageConfig.value, true); // 强制刷新
   location.reload();
 }
@@ -407,18 +539,22 @@ function updateStageConfig() {
       }
     }
   }
-  debugText.value = JSON.stringify(stageConfig.value, null, 2);
+  debugText.value = stringifyConfig(stageConfig.value);
 }
 
 
-//定时更新自定义一图流配置
-setInterval(updateStageConfig, 2000)
+// 定时更新自定义一图流配置
+// setInterval(updateStageConfig, 2000)
 
-// // 监听stageConfig的变化，保存配置到localStorage
-// watch(stageConfig, () => {
-//   debugText.value = JSON.stringify(stageConfig.value, null, 2);
-//   localStorage.setItem("StageConfig", JSON.stringify(stageConfig.value));
-// }, {deep: true});
+// 监听 stageConfig 的变化，保存配置到 localStorage
+watch(
+  stageConfig,
+  (newConfig) => {
+    debugText.value = stringifyConfig(newConfig);
+    localStorage.setItem("StageConfig", stringifyConfig(newConfig));
+  },
+  { deep: true },
+);
 
 // 初始化数据
 onMounted(() => {
@@ -432,7 +568,7 @@ onMounted(() => {
   <!-- 材料价值自定义参数主卡片 -->
   <v-card class="stage-config-card">
     <v-card-item>
-      <v-card-title>自定义材料价值参数</v-card-title>
+      <v-card-title>物品定价策略设置</v-card-title>
       <div class="cover-v-card-subtitle">
         <span>自定义参数用于定制更适合自己的刷图方案和购买策略<br>自定义参数保存于当前设备，后续将可通过一图流账号保存和同步</span>
       </div>
@@ -448,7 +584,6 @@ onMounted(() => {
 
       <!-- 主体内容 -->
       <div>
-        <!-- <v-list> -->
         <!-- 重要参数设置 -->
         <!-- 折叠面板：基础价值参数 -->
         <v-expansion-panels multiple v-model="stageConfigPanel">
@@ -458,9 +593,9 @@ onMounted(() => {
             </v-expansion-panel-title>
 
             <v-expansion-panel-text class="expansion-panel-text">
-            <span class="cover-v-expansion-panel-subtitle">
-              这里预制了一些参数，供大家快速选择
-            </span>
+              <span class="cover-v-expansion-panel-subtitle">
+                这里预制了一些参数，供大家快速选择
+              </span>
               <v-divider></v-divider>
               <div v-for="group in presetParameter" class="flex flex-wrap">
                 <v-card v-for="item in group" class="preset-parameter-card">
@@ -475,7 +610,7 @@ onMounted(() => {
                   <div style="height: 50px"></div>
 
                   <v-btn class="m-4 preset-parameter-card-action" @click="choosePresetParameter(item)"
-                         :color="item.color">
+                    :color="item.color">
                     应用
                   </v-btn>
                 </v-card>
@@ -490,30 +625,313 @@ onMounted(() => {
               基础材料价值参数设置
             </v-expansion-panel-title>
             <v-expansion-panel-text class="expansion-panel-text">
-              <!-- 经验书价值系数设置 -->
-              <v-list-item>
-                <v-list-item-title>
-                  经验书价值系数 — {{ formatNumber(stageConfig.expCoefficient, 4) }}
-                </v-list-item-title>
 
-                <span class="card-description">
-                  用于调整经验书的价值，经验书价值 = 0.0036 × 价值系数
-                </span>
-                <v-text-field v-model="stageConfig.expCoefficient" :rules="inputRules" variant="outlined"
-                              density="compact"></v-text-field>
-              </v-list-item>
+              <!-- 合成玉定价策略 -->
+              <v-radio-group v-model="stageConfig.orundumPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    合成玉定价策略
+                    <span class="card-description"
+                      v-if="stageConfig.orundumPricingStrategy === 'ORUNDUM_PRICING_ORIGINITE_PRIME'">
+                      180 合成玉 = 135 理智，1 合成玉 = 0.75 理智
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.orundumPricingStrategy === 'ORUNDUM_PRICING_ORININUM_FARMING_ORIROCK_CUBE'">
+                      10 合成玉 = 2 固源岩 + 1600 龙门币 + 40 无人机
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.orundumPricingStrategy === 'ORUNDUM_PRICING_ORININUM_FARMING_DEVICE'">
+                      10 合成玉 = 1 装置 + 1000 龙门币 + 40 无人机
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.orundumPricingStrategy === 'ORUNDUM_PRICING_INFINITY'">
+                      仅计算抽卡资源的价值，认为养成资源无价值（1 合成玉 = ∞ 理智）
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.orundumPricingStrategy === 'ORUNDUM_PRICING_CUSTOM'">
+                      1 合成玉 = {{ typeof stageConfig.orundumValue === "number" ? stageConfig.orundumValue : "?" }} 理智
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="ORUNDUM_PRICING_ORIGINITE_PRIME" label="碎石途径定价（默认）"></v-radio>
+                <v-radio value="ORUNDUM_PRICING_ORININUM_FARMING_ORIROCK_CUBE" label="搓玉途径定价（用固源岩搓玉）"></v-radio>
+                <v-radio value="ORUNDUM_PRICING_ORININUM_FARMING_DEVICE" label="搓玉途径定价（用装置搓玉）"></v-radio>
+                <v-radio value="ORUNDUM_PRICING_INFINITY" label="仅抽卡"></v-radio>
+                <v-radio value="ORUNDUM_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="orundumValueInput" v-model.number='stageConfig.orundumValue' :rules="numberGe0"
+                  label="1 合成玉 = ? 理智" @focus="stageConfig.orundumPricingStrategy = 'ORUNDUM_PRICING_CUSTOM'"
+                  placeholder="1 合成玉 = ? 理智" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
 
-              <!-- 龙门币价值系数设置 -->
-              <v-list-item>
-                <v-list-item-title>
-                  龙门币价值系数 — {{ formatNumber(stageConfig.lmdCoefficient, 4) }}
-                </v-list-item-title>
-                <span class="card-description">
-                  用于调整龙门币的价值，龙门币价值 = 0.0036 × 价值系数
-                </span>
-                <v-text-field v-model="stageConfig.lmdCoefficient" :rules="inputRules" variant="outlined"
-                              density="compact"></v-text-field>
-              </v-list-item>
+              <!-- 至纯源石定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.originitePrimePricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    至纯源石价值系数 — {{ formatNumber(stageConfig.originitePrimeCoefficient, 4) }}
+                    <span class="card-description">
+                      用于计算礼包性价比，至纯源石价值 = 合成玉价值 × 至纯源石价值系数
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="ORIGINITE_PRIME_PRICING_ORUNDUM" label="1 至纯源石 = 180 合成玉（默认）"></v-radio>
+                <v-radio value="ORIGINITE_PRIME_PRICING_INFINITY" label="1 至纯源石 = ∞ 合成玉（源石仅买装扮）"></v-radio>
+                <v-radio value="ORIGINITE_PRIME_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="originitePrimeCoefficientInput"
+                  v-model.number='stageConfig.originitePrimeCoefficient' :rules="numberGe0" label="至纯源石价值系数"
+                  @click="stageConfig.originitePrimePricingStrategy = 'ORIGINITE_PRIME_PRICING_CUSTOM'"
+                  @focus="stageConfig.originitePrimePricingStrategy = 'ORIGINITE_PRIME_PRICING_CUSTOM'"
+                  placeholder="1 至纯源石 = ? 合成玉" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- 中坚寻访系数 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.kernalHeadhuntingPermitPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    中坚寻访系数
+                    <span class="card-description">
+                      1 中坚寻访凭证 = {{ typeof stageConfig.kernalHeadhuntingPermitCoefficient === "number" ?
+                        stageConfig.kernalHeadhuntingPermitCoefficient : "?" }} 寻访凭证
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="KERNAL_HEADHUNTING_PERMIT_PRICING_DISTINCTION_CERTIFICATE"
+                  label="38 中坚寻访凭证 = 216 高级凭证（默认）"></v-radio>
+                <v-radio value="KERNAL_HEADHUNTING_PERMIT_PRICING_ZERO" label="中坚寻访凭证价值为 0"></v-radio>
+                <v-radio value="KERNAL_HEADHUNTING_PERMIT_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="kernalHeadhuntingPermitCoefficientInput"
+                  v-model.number='stageConfig.kernalHeadhuntingPermitCoefficient' :rules="numberGe0"
+                  @focus="stageConfig.kernalHeadhuntingPermitPricingStrategy = 'KERNAL_HEADHUNTING_PERMIT_PRICING_CUSTOM'"
+                  label="1 中坚寻访凭证 = ? 寻访凭证" placeholder="1 中坚寻访凭证 = ? 寻访凭证" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- 龙门币定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.lmdPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    龙门币价值系数 — {{ formatNumber(stageConfig.lmdCoefficient, 4) }}
+                    <span class="card-description">
+                      用于调整龙门币的价值，龙门币价值 = 0.0036 × 龙门币价值系数
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="LMD_PRICING_CE-6" label="按 CE-6 定价（默认）"></v-radio>
+                <v-radio value="LMD_PRICING_ZERO" label="龙门币价值为 0"></v-radio>
+                <v-radio value="LMD_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="lmdCoefficientInput" v-model.number='stageConfig.lmdCoefficient'
+                  :rules="numberBetween0And1" label="龙门币价值系数"
+                  @focus="stageConfig.lmdPricingStrategy = 'LMD_PRICING_CUSTOM'" placeholder="0 ~ 1 之间的数字"
+                  variant="outlined" density="compact" style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- EXP 定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.expPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    EXP 价值系数 — {{ formatNumber(stageConfig.expCoefficient, 4) }}
+                    <span class="card-description">
+                      用于调整 EXP 的价值，EXP 价值 = 0.0036 × EXP 价值系数
+                    </span>
+                  </div>
+                </template>
+                <!-- 按 LS-6 定价 -->
+                <v-radio value="EXP_PRICING_LS-6" label="按 LS-6 定价"></v-radio>
+                <!-- EXP 价值为 0 -->
+                <v-radio value="EXP_PRICING_ZERO" label="EXP 价值为 0"></v-radio>
+                <!-- 按无人机定价（默认），3 级贸易站，不使用龙舌兰、但书、裁缝类技能 -->
+                <v-radio value="EXP_PRICING_BASE_LVL_3_TP">
+                  <template v-slot:label>
+                    <div>
+                      按无人机定价（默认）
+                      <span class="card-description">
+                        3 级贸易站，不使用龙舌兰、但书、裁缝类技能
+                      </span>
+                    </div>
+                  </template>
+                </v-radio>
+                <!-- 按无人机定价，3 级贸易站，使用精 2 龙舌兰、精 2 但书、不使用裁缝类技能 -->
+                <v-radio value="EXP_PRICING_BASE_LVL_3_TP_TEQUILA_2_PROVISO_2">
+                  <template v-slot:label>
+                    <div>
+                      按无人机定价
+                      <span class="card-description">
+                        3 级贸易站，使用精 2 龙舌兰、精 2 但书，不使用裁缝类技能
+                      </span>
+                    </div>
+                  </template>
+                </v-radio>
+                <!-- 按无人机定价，2 级贸易站，使用精 2 但书，不使用龙舌兰、裁缝类技能 -->
+                <v-radio value="EXP_PRICING_BASE_LVL_2_TP_PROVISO_2">
+                  <template v-slot:label>
+                    <div>
+                      按无人机定价
+                      <span class="card-description">
+                        2 级贸易站，使用精 2 但书，不使用龙舌兰、裁缝类技能
+                      </span>
+                    </div>
+                  </template>
+                </v-radio>
+                <!-- 按无人机定价，1 级贸易站，使用精 2 但书，不使用龙舌兰、裁缝类技能 -->
+                <v-radio value="EXP_PRICING_BASE_LVL_1_TP_PROVISO_2">
+                  <template v-slot:label>
+                    <div>
+                      按无人机定价
+                      <span class="card-description">
+                        1 级贸易站，使用精 2 但书，不使用龙舌兰、裁缝类技能
+                      </span>
+                    </div>
+                  </template>
+                </v-radio>
+                <!-- 自定义 -->
+                <v-radio value="EXP_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="expCoefficientInput" v-model.number='stageConfig.expCoefficient'
+                  :rules="numberBetween0And1" label="EXP 价值系数"
+                  @focus="stageConfig.expPricingStrategy = 'EXP_PRICING_CUSTOM'" placeholder="0 ~ 1 之间的数字"
+                  variant="outlined" density="compact" style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- 模组数据块定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.modUnlockTokenPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    模组数据块定价策略
+                    <span class="card-description"
+                      v-if="stageConfig.modUnlockTokenPricingStrategy === 'MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE'">
+                      1 模组数据块 = 120 采购凭证
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.modUnlockTokenPricingStrategy === 'MOD_UNLOCK_TOKEN_PRICING_DISTINCTION_CERTIFICATE'">
+                      1 模组数据块 = 20 高级凭证
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.modUnlockTokenPricingStrategy === 'MOD_UNLOCK_TOKEN_PRICING_CUSTOM'">
+                      1 模组数据块 = {{ typeof stageConfig.modUnlockTokenValue === "number" ? stageConfig.modUnlockTokenValue
+                        : "?" }} 理智
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE" label="采购凭证区定价（默认）"></v-radio>
+                <v-radio value="MOD_UNLOCK_TOKEN_PRICING_DISTINCTION_CERTIFICATE" label="高级凭证区定价"></v-radio>
+                <v-radio value="MOD_UNLOCK_TOKEN_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="modUnlockTokenValueInput" v-model.number='stageConfig.modUnlockTokenValue'
+                  :rules="numberGe0" label="1 模组数据块 = ? 理智"
+                  @focus="stageConfig.modUnlockTokenPricingStrategy = 'MOD_UNLOCK_TOKEN_PRICING_CUSTOM'"
+                  placeholder="1 模组数据块 = ? 理智" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- 招聘许可定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.recruitmentPermitPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    招聘许可定价策略
+                    <span class="card-description"
+                      v-if="stageConfig.recruitmentPermitPricingStrategy === 'RECRUITMENT_PERMIT_PRICING_3_4'">
+                      认为公开招募范围内的 3★、4★ 干员潜能均已满，5★、6★ 干员均已获得但潜能未满
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.recruitmentPermitPricingStrategy === 'RECRUITMENT_PERMIT_PRICING_3_4_5'">
+                      认为公开招募范围内的 3★、4★、5★ 干员潜能均已满，6★ 干员均已获得但潜能未满
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.recruitmentPermitPricingStrategy === 'RECRUITMENT_PERMIT_PRICING_3_4_5_6'">
+                      认为公开招募范围内的干员潜能均已满
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.recruitmentPermitPricingStrategy === 'RECRUITMENT_PERMIT_PRICING_CUSTOM'">
+                      1 招聘许可 = {{ typeof stageConfig.recruitmentPermitValue === "number" ?
+                        stageConfig.recruitmentPermitValue : "?" }} 理智
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="RECRUITMENT_PERMIT_PRICING_3_4" label="5★、6★ 未满潜（默认）"></v-radio>
+                <v-radio value="RECRUITMENT_PERMIT_PRICING_3_4_5" label="5★ 全满潜，6★ 未满潜"></v-radio>
+                <v-radio value="RECRUITMENT_PERMIT_PRICING_3_4_5_6" label="全满潜"></v-radio>
+                <v-radio value="RECRUITMENT_PERMIT_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="recruitmentPermitValueInput" v-model.number='stageConfig.recruitmentPermitValue'
+                  :rules="numberGe0" label="1 招聘许可 = ? 理智"
+                  @focus="stageConfig.recruitmentPermitPricingStrategy = 'RECRUITMENT_PERMIT_PRICING_CUSTOM'"
+                  placeholder="1 招聘许可 = ? 理智" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- 加急许可定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.expeditedPlanPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    加急许可定价策略
+                    <span class="card-description"
+                      v-if="stageConfig.expeditedPlanPricingStrategy === 'EXPEDITED_PLAN_PRICING_ZERO'">
+                      1 加急许可 = 0 理智
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.expeditedPlanPricingStrategy === 'EXPEDITED_PLAN_PRICING_RECRUITMENT_PERMIT'">
+                      1 加急许可 = 1 招聘许可
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.expeditedPlanPricingStrategy === 'EXPEDITED_PLAN_PRICING_CUSTOM'">
+                      1 加急许可 = {{ typeof stageConfig.expeditedPlanValue === "number" ? stageConfig.expeditedPlanValue :
+                        "?" }} 理智
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="EXPEDITED_PLAN_PRICING_ZERO" label="加急许可价值为 0（默认）"></v-radio>
+                <v-radio value="EXPEDITED_PLAN_PRICING_RECRUITMENT_PERMIT" label="等于招聘许可的价值"></v-radio>
+                <v-radio value="EXPEDITED_PLAN_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="expeditedPlanValueInput" v-model.number='stageConfig.expeditedPlanValue'
+                  :rules="numberGe0" label="1 加急许可 = ? 理智"
+                  @focus="stageConfig.expeditedPlanPricingStrategy = 'EXPEDITED_PLAN_PRICING_CUSTOM'"
+                  placeholder="1 加急许可 = ? 理智" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
+
+              <!-- 家具零件定价策略 -->
+              <v-divider></v-divider>
+              <v-radio-group v-model="stageConfig.furniturePartPricingStrategy">
+                <template v-slot:label>
+                  <div>
+                    家具零件定价策略
+                    <span class="card-description"
+                      v-if="stageConfig.furniturePartPricingStrategy === 'FURNITURE_PART_PRICING_ZERO'">
+                      1 家具零件 = 0 理智
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.furniturePartPricingStrategy === 'FURNITURE_PART_PRICING_SK-5'">
+                      刷 SK-5 获取家具零件
+                    </span>
+                    <span class="card-description"
+                      v-else-if="stageConfig.furniturePartPricingStrategy === 'FURNITURE_PART_PRICING_CUSTOM'">
+                      1 家具零件 = {{ typeof stageConfig.furniturePartValue === "number" ? stageConfig.furniturePartValue :
+                        "?" }} 理智
+                    </span>
+                  </div>
+                </template>
+                <v-radio value="FURNITURE_PART_PRICING_ZERO" label="家具零件价值为 0（默认）"></v-radio>
+                <v-radio value="FURNITURE_PART_PRICING_SK-5" label="按 SK-5 定价（暂未实现）"></v-radio>
+                <v-radio value="FURNITURE_PART_PRICING_CUSTOM" label="自定义"></v-radio>
+                <v-text-field ref="furniturePartValueInput" v-model.number='stageConfig.furniturePartValue'
+                  :rules="numberGe0" @focus="stageConfig.furniturePartPricingStrategy = 'FURNITURE_PART_PRICING_CUSTOM'"
+                  label="1 家具零件 = ? 理智" placeholder="1 家具零件 = ? 理智" variant="outlined" density="compact"
+                  style="margin-left: 40px; width: 200px;">
+                </v-text-field>
+              </v-radio-group>
             </v-expansion-panel-text>
           </v-expansion-panel>
 
@@ -532,13 +950,13 @@ onMounted(() => {
 
                 <div class="m-8-0 font-bold color-primary">快捷选择</div>
                 <ActionButton v-for="(stage, stageCode) in BeastsStage" :btn-text="stageCode" :active="stage.active"
-                              @click="updateBeastsStageActive(stage)">
+                  @click="updateBeastsStageActive(stage)">
                 </ActionButton>
 
 
                 <div class="m-8-0 font-bold color-primary">活动关</div>
                 <ActionButton :btn-text="'SideStory定价测试集'" :active="stageConfig.useActivityAverageStage"
-                              @click="useActivityAverageStage()">
+                  @click="useActivityAverageStage()">
                 </ActionButton>
 
                 <div class="m-8-0 font-bold color-primary">主题曲</div>
@@ -547,13 +965,13 @@ onMounted(() => {
 
                   <!--              <div class="m-4">  {{ collect.zoneName}} </div>-->
                   <v-checkbox density="compact" hide-details color="primary" v-model="collect.selectAll"
-                              @click="selectAllStage(collect)">
+                    @click="selectAllStage(collect)">
                     <template v-slot:prepend>
                       {{ collect.zoneName }}
                     </template>
                   </v-checkbox>
                   <ActionButton v-for="(stage, index) in collect.list" :btn-text="stage.stageCode"
-                                :active="stage.active" @click="updateStageBlacklist(collect,stage)">
+                    :active="stage.active" @click="updateStageBlacklist(collect, stage)">
                   </ActionButton>
                   <!--              <v-divider class="opacity-70 m-4-0"></v-divider>-->
                 </div>
@@ -563,13 +981,13 @@ onMounted(() => {
                 <v-divider color="primary" class="opacity-50"></v-divider>
                 <div v-for="(collect, index) in stageCollect.ActPerm" :key="index">
                   <v-checkbox density="compact" hide-details color="primary" v-model="collect.selectAll"
-                              @click="selectAllStage(collect)">
+                    @click="selectAllStage(collect)">
                     <template v-slot:prepend>
                       {{ collect.zoneName }}
                     </template>
                   </v-checkbox>
                   <ActionButton v-for="(stage, index) in collect.list" :btn-text="stage.stageCode"
-                                :active="stage.active" @click="updateStageBlacklist(collect,stage)">
+                    :active="stage.active" @click="updateStageBlacklist(collect, stage)">
                   </ActionButton>
                   <!--              <v-divider class="opacity-70 m-4-0"></v-divider>-->
                 </div>
@@ -581,9 +999,9 @@ onMounted(() => {
           </v-expansion-panel>
 
 
-          <!-- 折叠面板：自定义材料价值设置 -->
+          <!-- 折叠面板：自定义精英材料价值设置 -->
 
-          <v-expansion-panel title="自定义材料价值" value="custom-item-value">
+          <v-expansion-panel title="自定义精英材料价值" value="custom-item-value">
             <v-expansion-panel-text class="expansion-panel-text">
 
               <v-list>
@@ -593,41 +1011,40 @@ onMounted(() => {
                   </v-list-item-title>
                   <div class="flex flex-wrap">
                     <ItemImage v-for="item in actStoreUnlimitedExchangeItem" :item-id="item.itemId" :size="50"
-                               :mobile-size="40" :class="actStoreUnlimitedExchangeItemActiveClass(item.active)"
-                               @click="chooseActStoreUnlimitedExchangeItem(item)"></ItemImage>
+                      :mobile-size="40" :class="actStoreUnlimitedExchangeItemActiveClass(item.active)"
+                      @click="chooseActStoreUnlimitedExchangeItem(item)"></ItemImage>
                   </div>
-<!--                  {{actStoreUnlimitedExchangeItem}}-->
+                  <!--                  {{actStoreUnlimitedExchangeItem}}-->
                 </v-list-item>
 
                 <v-list-item>
                   <v-list-item-title>
-                    自定义材料价值
+                    自定义精英材料价值
                   </v-list-item-title>
                   <!-- 按钮：打开自定义材料弹窗 -->
-                  <v-btn color="primary" variant="outlined" size="small" text="新增自定义材料"
-                         @click="customItemDialog = true"
-                         class="m-12-0"></v-btn>
+                  <v-btn color="primary" variant="outlined" size="small" text="新增自定义材料" @click="customItemDialog = true"
+                    class="m-12-0"></v-btn>
                   <!-- 自定义材料列表：显示已添加的自定义材料及其价值 -->
                   <v-table>
                     <thead>
-                    <tr>
-                      <th>材料</th>
-                      <th>自定义价值</th>
-                      <th>操作</th>
-                    </tr>
+                      <tr>
+                        <th>材料</th>
+                        <th>自定义价值</th>
+                        <th>操作</th>
+                      </tr>
                     </thead>
                     <tbody>
-                    <tr v-for="item in stageConfig.customItem">
-                      <td>
-                        <!-- 显示材料的图标 -->
-                        <ItemImage :size="60" :mobile-size="40" :item-id="item.itemId"></ItemImage>
-                      </td>
-                      <td>{{ item.itemValue }}</td>
-                      <td>
-                        <!-- 删除按钮：用于移除自定义材料 -->
-                        <v-btn color="red" text="删除" @click="deleteCustomItem(item.itemId)"></v-btn>
-                      </td>
-                    </tr>
+                      <tr v-for="item in stageConfig.customItem">
+                        <td>
+                          <!-- 显示材料的图标 -->
+                          <ItemImage :size="60" :mobile-size="40" :item-id="item.itemId"></ItemImage>
+                        </td>
+                        <td>{{ item.itemValue }}</td>
+                        <td>
+                          <!-- 删除按钮：用于移除自定义材料 -->
+                          <v-btn color="red" text="删除" @click="deleteCustomItem(item.itemId)"></v-btn>
+                        </td>
+                      </tr>
                     </tbody>
                   </v-table>
                 </v-list-item>
@@ -646,8 +1063,8 @@ onMounted(() => {
                   debug
                 </v-list-item-title>
                 <!-- 显示调试信息 -->
-                <textarea v-model="debugText" style="height: 700px;width: 100%" class="m-4">
-        </textarea>
+                <pre><code style="white-space: pre-wrap; font-family: 'Jetbrains Mono', Consolas, 'Courier New', monospace;">{{
+                  debugText }}</code></pre>
               </v-list-item>
             </v-expansion-panel-text>
           </v-expansion-panel>
@@ -684,8 +1101,8 @@ onMounted(() => {
         <v-list-item title="可选材料">
           <div class="flex flex-wrap justify-center">
             <!-- 显示所有可选的材料图标，点击后选择该材料 -->
-            <ItemImage v-for="item in itemList" :item-id="item.itemId" :size="60" :mobile-size="40"
-                       @click="chooseCustomItem(item)">
+            <ItemImage v-for="item in itemList.filter((item) => isEliteMaterial(item.itemId))" :item-id="item.itemId"
+              :size="60" :mobile-size="40" @click="chooseCustomItem(item)">
             </ItemImage>
           </div>
         </v-list-item>

--- a/src/components/account/StageConfig.vue
+++ b/src/components/account/StageConfig.vue
@@ -706,7 +706,7 @@ onMounted(() => {
                     中坚寻访系数
                     <span class="card-description">
                       1 中坚寻访凭证 = {{ typeof stageConfig.kernalHeadhuntingPermitCoefficient === "number" ?
-                        stageConfig.kernalHeadhuntingPermitCoefficient : "?" }} 寻访凭证
+                      stageConfig.kernalHeadhuntingPermitCoefficient : "?" }} 寻访凭证
                     </span>
                   </div>
                 </template>
@@ -828,7 +828,7 @@ onMounted(() => {
                     <span class="card-description"
                       v-else-if="stageConfig.modUnlockTokenPricingStrategy === 'MOD_UNLOCK_TOKEN_PRICING_CUSTOM'">
                       1 模组数据块 = {{ typeof stageConfig.modUnlockTokenValue === "number" ? stageConfig.modUnlockTokenValue
-                        : "?" }} 理智
+                      : "?" }} 理智
                     </span>
                   </div>
                 </template>
@@ -864,7 +864,7 @@ onMounted(() => {
                     <span class="card-description"
                       v-else-if="stageConfig.recruitmentPermitPricingStrategy === 'RECRUITMENT_PERMIT_PRICING_CUSTOM'">
                       1 招聘许可 = {{ typeof stageConfig.recruitmentPermitValue === "number" ?
-                        stageConfig.recruitmentPermitValue : "?" }} 理智
+                      stageConfig.recruitmentPermitValue : "?" }} 理智
                     </span>
                   </div>
                 </template>
@@ -897,7 +897,7 @@ onMounted(() => {
                     <span class="card-description"
                       v-else-if="stageConfig.expeditedPlanPricingStrategy === 'EXPEDITED_PLAN_PRICING_CUSTOM'">
                       1 加急许可 = {{ typeof stageConfig.expeditedPlanValue === "number" ? stageConfig.expeditedPlanValue :
-                        "?" }} 理智
+                      "?" }} 理智
                     </span>
                   </div>
                 </template>
@@ -929,7 +929,7 @@ onMounted(() => {
                     <span class="card-description"
                       v-else-if="stageConfig.furniturePartPricingStrategy === 'FURNITURE_PART_PRICING_CUSTOM'">
                       1 家具零件 = {{ typeof stageConfig.furniturePartValue === "number" ? stageConfig.furniturePartValue :
-                        "?" }} 理智
+                      "?" }} 理智
                     </span>
                   </div>
                 </template>
@@ -1109,6 +1109,7 @@ onMounted(() => {
 
         <!-- 可选材料列表 -->
         <v-list-item title="可选材料">
+          <p>不建议自定义<span class="green">绿</span>、<span class="gray">白</span>材料的价值，这可能导致不自洽的结果</p>
           <div class="flex flex-wrap justify-center">
             <!-- 显示所有可选的材料图标，点击后选择该材料 -->
             <ItemImage v-for="item in itemList.filter((item) => isEliteMaterial(item.itemId))" :item-id="item.itemId"

--- a/src/plugins/indexedDB/penguinData.js
+++ b/src/plugins/indexedDB/penguinData.js
@@ -1,6 +1,17 @@
 import itemCache from "@/plugins/indexedDB/itemCache.js";
 import ytlStageInfo from '/src/static/json/material/ytl_stage_info.json'
 
+
+/**
+ * - 样本数小于 `stageConfig.sampleSize` 的作战不会包含在结果中
+ * - `useStageBlacklist` 为真时，`stageConfig.stageBlacklist` 中的作战不会包含在结果中
+ * - 无论 `stageConfig.useActivityStage` 和 `stageConfig.useActivityAverageStage` 真假，返回的结果总是包含活动作战
+ *
+ * @param {StageConfig} stageConfig
+ * @param {boolean} useStageBlacklist
+ * @returns {Promise<Map<string, Array<StageDrop>>>}
+ * key 为作战 ID，value 为掉落列表，下标为 1 的元素为龙门币掉落，下标为 2 的元素为活动商店无限龙门币（如果是活动关）
+ */
 async function getStageDropCollect(stageConfig, useStageBlacklist) {
 
     let penguinMatrix = []
@@ -10,7 +21,7 @@ async function getStageDropCollect(stageConfig, useStageBlacklist) {
     let stageInfoList = await itemCache.getStageInfoCache()
     let stageInfoMap = new Map()
     for (const stage of stageInfoList) {
-        const {stageId} = stage
+        const { stageId } = stage
         // console.log(stage)
         stageInfoMap.set(stageId, stage)
     }
@@ -25,7 +36,7 @@ async function getStageDropCollect(stageConfig, useStageBlacklist) {
 
     let stageBlacklistMap = new Map()
 
-    if (stageConfig.stageBlacklist&&useStageBlacklist) {
+    if (stageConfig.stageBlacklist && useStageBlacklist) {
         for (const item of stageConfig.stageBlacklist) {
             stageBlacklistMap.set(item, 1)
         }
@@ -40,7 +51,7 @@ async function getStageDropCollect(stageConfig, useStageBlacklist) {
 
     for (let item of penguinMatrix) {
 
-        const {stageId, itemId, quantity, times, start, end} = item
+        const { stageId, itemId, quantity, times, start, end } = item
 
         if (stageBlacklistMap.get(stageId)) {
             continue
@@ -83,7 +94,7 @@ async function getStageDropCollect(stageConfig, useStageBlacklist) {
             }
         }
 
-        const {stageCode, apCost, spm, stageType, zoneName, zoneId} = stageInfo
+        const { stageCode, apCost, spm, stageType, zoneName, zoneId } = stageInfo
 
         if (stageType === 'ACT' && apCost === 21 && ytlStageInfo[itemId]) {
             ytlStageInfo[itemId].quantity += item.quantity
@@ -156,4 +167,4 @@ async function getStageDropCollect(stageConfig, useStageBlacklist) {
     return stageDropCollect
 }
 
-export {getStageDropCollect}
+export { getStageDropCollect }

--- a/src/static/json/material/item_info.json
+++ b/src/static/json/material/item_info.json
@@ -594,6 +594,15 @@
     "itemValue": 24.068
   },
   {
+    "itemId": "7002",
+    "itemName": "加急许可",
+    "itemValueAp": 0,
+    "rarity": 4,
+    "cardNum": 12,
+    "weight": 0,
+    "itemValue": 0
+  },
+  {
     "itemId": "4006",
     "itemName": "采购凭证",
     "itemValueAp": 1.366857142857143,
@@ -864,15 +873,6 @@
     "itemValue": 0.8
   },
   {
-    "itemId": "4003sp",
-    "itemName": "合成玉(搓玉)",
-    "itemValueAp": 1.43438,
-    "rarity": 5,
-    "cardNum": 10,
-    "weight": 0,
-    "itemValue": 1.43438
-  },
-  {
     "itemId": "classic_gacha",
     "itemName": "中坚寻访凭证",
     "itemValueAp": 376.7442,
@@ -1112,15 +1112,6 @@
     "itemValueAp": 0,
     "rarity": 3,
     "cardNum": 12,
-    "weight": 0,
-    "itemValue": 0
-  },
-  {
-    "itemId": "7002",
-    "itemName": "加急许可",
-    "itemValueAp": 0,
-    "rarity": 4,
-    "cardNum": 100,
     "weight": 0,
     "itemValue": 0
   }

--- a/src/static/json/material/preset_parameter.json
+++ b/src/static/json/material/preset_parameter.json
@@ -1,6 +1,37 @@
 [
   [
     {
+      "name": "默认",
+      "description": [
+        "一图流的默认配置"
+      ],
+      "paramDescription": [
+        "1 至纯源石 = 180 合成玉 = 135 理智",
+        "中坚寻访凭证按高级凭证区定价",
+        "龙门币按 CE-6 定价",
+        "EXP 按无人机定价（3 级站，无龙但裁缝）",
+        "模组数据块按采购凭证区定价",
+        "公招 5★、6★ 未满潜",
+        "加急许可、家具零件价值为 0",
+        "精英材料主线定价"
+      ],
+      "parameters": {
+        "orundumPricingStrategy": "ORUNDUM_PRICING_ORIGINITE_PRIME",
+        "originitePrimePricingStrategy": "ORIGINITE_PRIME_PRICING_ORUNDUM",
+        "kernalHeadhuntingPermitPricingStrategy": "KERNAL_HEADHUNTING_PERMIT_PRICING_DISTINCTION_CERTIFICATE",
+        "lmdPricingStrategy": "LMD_PRICING_CE-6",
+        "expPricingStrategy": "EXP_PRICING_BASE_LVL_3_TP",
+        "modUnlockTokenPricingStrategy": "MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE",
+        "recruitmentPermitPricingStrategy": "RECRUITMENT_PERMIT_PRICING_3_4",
+        "expeditedPlanPricingStrategy": "EXPEDITED_PLAN_PRICING_ZERO",
+        "furniturePartsPricingStrategy": "FURNITURE_PARTS_PRICING_ZERO",
+        "useActivityAverageStage": false
+      },
+      "message": "已修改为默认配置",
+      "color": "primary",
+      "active": false
+    },
+    {
       "name": "萌新",
       "description": [
         "适合初入坑的博士",
@@ -8,16 +39,18 @@
         "基建尚未成型"
       ],
       "paramDescription": [
-        "经验书系数=0.9568",
-        "龙门币系数=1",
-        "主线定价"
+        "龙门币按 CE-6 定价",
+        "EXP 按 LS-6 定价",
+        "公招 5★、6★ 未满潜",
+        "精英材料主线定价"
       ],
       "parameters": {
-        "expCoefficient": 0.9568,
-        "lmdCoefficient": 1,
-        "useActivityAverageStage":false
+        "lmdPricingStrategy": "LMD_PRICING_CE-6",
+        "expPricingStrategy": "EXP_PRICING_LS-6",
+        "recruitmentPermitPricingStrategy": "RECRUITMENT_PERMIT_PRICING_3_4",
+        "useActivityAverageStage": false
       },
-      "message": "经验书系数已修改为0.9568；龙门币系数已修改为1；已使用主线与常驻活动关卡作为基准",
+      "message": "已修改为萌新配置",
       "color": "primary",
       "active": false
     },
@@ -29,16 +62,16 @@
         "基建已基本成型"
       ],
       "paramDescription": [
-        "经验书系数=0.633",
-        "龙门币系数=1",
-        "主线定价"
+        "龙门币按 CE-6 定价",
+        "EXP 按无人机定价（3 级站，无龙但裁缝）",
+        "精英材料主线定价"
       ],
       "parameters": {
-        "expCoefficient": 0.633,
-        "lmdCoefficient": 1,
-        "useActivityAverageStage":false
+        "lmdPricingStrategy": "LMD_PRICING_CE-6",
+        "expPricingStrategy": "EXP_PRICING_BASE_LVL_3_TP",
+        "useActivityAverageStage": false
       },
-      "message": "经验书系数已修改为0.633；龙门币系数已修改为1；已使用主线与常驻活动关卡作为基准",
+      "message": "已修改为成长中的博士配置",
       "color": "primary",
       "active": false
     },
@@ -50,70 +83,43 @@
         "蓝材料的主要来源为SS，且均有100或更多的储备"
       ],
       "paramDescription": [
-        "经验书系数=0.633",
-        "龙门币系数=1",
-        "活动关定价"
+        "龙门币按 CE-6 定价",
+        "EXP 按无人机定价（3 级站，有龙但）",
+        "加急许可、家具零件价值为 0",
+        "精英材料活动定价"
       ],
       "parameters": {
-        "expCoefficient": 0.633,
-        "lmdCoefficient": 1,
-        "useActivityAverageStage":true
+        "lmdPricingStrategy": "LMD_PRICING_CE-6",
+        "expPricingStrategy": "EXP_PRICING_BASE_LVL_3_TP_TEQUILA_2_PROVISO_2",
+        "expeditedPlanPricingStrategy": "EXPEDITED_PLAN_PRICING_ZERO",
+        "furniturePartsPricingStrategy": "FURNITURE_PARTS_PRICING_ZERO",
+        "useActivityAverageStage": true
       },
-      "message": "经验书系数已修改为0.633；龙门币系数已修改为1；已使用活动掉率作为基准",
-      "color": "primary",
-      "active": false
-    }
-  ],
-  [
-    {
-      "name": "我会刷龙门币",
-      "description": [],
-      "paramDescription": [
-        "龙门币系数=1"
-      ],
-      "parameters": {
-        "lmdCoefficient": 1
-      },
-      "message": "龙门币系数已修改为1",
+      "message": "已修改为老登配置",
       "color": "primary",
       "active": false
     },
     {
-      "name": "我龙门币溢出",
+      "name": "仅抽卡",
       "description": [],
-      "paramDescription": [
-        "龙门币系数=0"
-      ],
+      "paramDescription": [],
       "parameters": {
-        "lmdCoefficient": 0
+        "orundumPricingStrategy": "ORUNDUM_PRICING_INFINITY",
+        "originitePrimePricingStrategy": "ORIGINITE_PRIME_PRICING_ORUNDUM"
       },
-      "message": "龙门币系数已修改为0",
+      "message": "已修改为仅抽卡配置",
       "color": "primary",
       "active": false
     },
     {
-      "name": "我会刷经验书",
+      "name": "只看源石",
       "description": [],
-      "paramDescription": [
-        "经验书系数=0.9568"
-      ],
+      "paramDescription": [],
       "parameters": {
-        "expCoefficient": 0.9568
+        "orundumPricingStrategy": "ORUNDUM_PRICING_INFINITY",
+        "originitePrimePricingStrategy": "ORIGINITE_PRIME_PRICING_INFINITY"
       },
-      "message": "经验书系数已修改为0.9568",
-      "color": "primary",
-      "active": false
-    },
-    {
-      "name": "我经验书溢出",
-      "description": [],
-      "paramDescription": [
-        "经验书系数=0"
-      ],
-      "parameters": {
-        "expCoefficient": 0
-      },
-      "message": "经验书系数已修改为0",
+      "message": "已修改为只看源石配置",
       "color": "primary",
       "active": false
     }

--- a/src/static/json/material/store_perm_table.json
+++ b/src/static/json/material/store_perm_table.json
@@ -1031,6 +1031,22 @@
       "price": 200.0,
       "quantity": 3,
       "rarity": 3
+    },
+    {
+      "itemId": "7002",
+      "itemName": "加急许可",
+      "storeType": "grey",
+      "price": 160.0,
+      "quantity": 1,
+      "rarity": 4
+    },
+    {
+      "itemId": "3401",
+      "itemName": "家具零件",
+      "storeType": "grey",
+      "price": 160.0,
+      "quantity": 20,
+      "rarity": 3
     }
   ]
 }

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -9,7 +9,7 @@ import {h} from 'vue'
 const formatNumber = (num, acc = 2) => {
     acc = typeof acc !== "undefined" ? acc : 2;
     if (typeof num === "undefined") return ''
-    return parseFloat(num.toString()).toFixed(acc);
+    return parseFloat(num?.toString()).toFixed(acc);
 }
 
 // 将 HTML 字符串转换成包含层级结构的 VNode

--- a/src/utils/item/itemValue.js
+++ b/src/utils/item/itemValue.js
@@ -1,9 +1,7 @@
+import { getStageDropCollect } from "@/plugins/indexedDB/penguinData.js";
 import ITEM_INFO from "@/static/json/material/item_info.json";
-import COMPOSITE_TABLE from '/src/static/json/material/composite_table.v2.json'
-
-import {getStageDropCollect} from "@/plugins/indexedDB/penguinData.js";
-import {itemSeriesInfoByItemId} from "/src/utils/item/itemSeries.js";
-// import {updateItemInfoWeight} from "/src/utils/item/updateItemInfoWeight.js";
+import COMPOSITE_TABLE from '/src/static/json/material/composite_table.v2.json';
+import { itemSeriesInfoByItemId } from "/src/utils/item/itemSeries.js";
 
 
 //加工站每级期望产出理智初始值
@@ -16,25 +14,25 @@ let workShopProducts = {
 
 //每种精英物品的初始迭代值
 let itemValueCorrectionTerm = {
-    30013: {correctionTerm: 1.00000137324044, itemName: '固源岩组'},
-    30023: {correctionTerm: 1.0000040009822255, itemName: '糖组'},
-    30033: {correctionTerm: 1.0000019925398336, itemName: '聚酸酯组'},
-    30043: {correctionTerm: 0.9999483750088554, itemName: '异铁组'},
-    30053: {correctionTerm: 1.0000022954075312, itemName: '酮凝集组'},
-    30063: {correctionTerm: 1.0000013169421755, itemName: '全新装置'},
-    30073: {correctionTerm: 0.9999649132885954, itemName: '扭转醇'},
-    30083: {correctionTerm: 1.000002240727396, itemName: '轻锰矿'},
-    30093: {correctionTerm: 1.0000022806201772, itemName: '研磨石'},
-    30103: {correctionTerm: 1.0000130948559616, itemName: 'RMA70-12'},
-    31013: {correctionTerm: 0.9999904276257087, itemName: '凝胶'},
-    31023: {correctionTerm: 1.0000248495124442, itemName: '炽合金'},
-    31033: {correctionTerm: 1.00000158366126, itemName: '晶体元件'},
-    31043: {correctionTerm: 0.999997836003829, itemName: '半自然溶剂'},
-    31053: {correctionTerm: 1.000006210539448, itemName: '化合切削液'},
-    31063: {correctionTerm: 0.9999981294168673, itemName: '转质盐组'},
-    31073: {correctionTerm: 1.0001889176671603, itemName: '褐素纤维'},
-    31083: {correctionTerm: 0.9996130718228801, itemName: '环烃聚质'},
-    31093: {correctionTerm: 0.9996130718228801, itemName: '类凝结核'}
+    30013: { correctionTerm: 1.00000137324044, itemName: '固源岩组' },
+    30023: { correctionTerm: 1.0000040009822255, itemName: '糖组' },
+    30033: { correctionTerm: 1.0000019925398336, itemName: '聚酸酯组' },
+    30043: { correctionTerm: 0.9999483750088554, itemName: '异铁组' },
+    30053: { correctionTerm: 1.0000022954075312, itemName: '酮凝集组' },
+    30063: { correctionTerm: 1.0000013169421755, itemName: '全新装置' },
+    30073: { correctionTerm: 0.9999649132885954, itemName: '扭转醇' },
+    30083: { correctionTerm: 1.000002240727396, itemName: '轻锰矿' },
+    30093: { correctionTerm: 1.0000022806201772, itemName: '研磨石' },
+    30103: { correctionTerm: 1.0000130948559616, itemName: 'RMA70-12' },
+    31013: { correctionTerm: 0.9999904276257087, itemName: '凝胶' },
+    31023: { correctionTerm: 1.0000248495124442, itemName: '炽合金' },
+    31033: { correctionTerm: 1.00000158366126, itemName: '晶体元件' },
+    31043: { correctionTerm: 0.999997836003829, itemName: '半自然溶剂' },
+    31053: { correctionTerm: 1.000006210539448, itemName: '化合切削液' },
+    31063: { correctionTerm: 0.9999981294168673, itemName: '转质盐组' },
+    31073: { correctionTerm: 1.0001889176671603, itemName: '褐素纤维' },
+    31083: { correctionTerm: 0.9996130718228801, itemName: '环烃聚质' },
+    31093: { correctionTerm: 0.9996130718228801, itemName: '类凝结核' }
 }
 
 //物品信息列表
@@ -45,9 +43,10 @@ let stageDropCollect = void 0
 
 //基础龙门币价值（按CE6  10000龙门币=36理智）
 const baseLMDValue = 0.0036
+const baseEXPValue = 0.0036
 
 // 公开招募结果的星级概率分布
-let recruitRarity = {
+const recruitRarity = {
     "3": 0.7882,
     "4": 0.2027,
     "5": 0.0069,
@@ -55,12 +54,32 @@ let recruitRarity = {
 }
 
 // 公开招募获得的凭证数量
-let recruitToken = {
-    "3": {"4005": 10, "4004": 0},
-    "4": {"4005": 30, "4004": 1},
-    "5": {"4005": 0, "4004": 5},
-    "6": {"4005": 0, "4004": 10},
+const recruitTokenMap = {
+    "RECRUITMENT_PERMIT_PRICING_3_4": {
+        "3": { "4005": 10, "4004": 0 },
+        "4": { "4005": 30, "4004": 1 },
+        "5": { "4005": 0, "4004": 5 },
+        "6": { "4005": 0, "4004": 10 },
+    },
+    "RECRUITMENT_PERMIT_PRICING_3_4_5": {
+        "3": { "4005": 10, "4004": 0 },
+        "4": { "4005": 30, "4004": 1 },
+        "5": { "4005": 0, "4004": 13 },
+        "6": { "4005": 0, "4004": 10 },
+    },
+    "RECRUITMENT_PERMIT_PRICING_3_4_5_6": {
+        "3": { "4005": 10, "4004": 0 },
+        "4": { "4005": 30, "4004": 1 },
+        "5": { "4005": 0, "4004": 13 },
+        "6": { "4005": 0, "4004": 25 },
+    }
 }
+
+/**
+ *
+ * @param {*} stageConfig 关卡自定义配置
+ */
+function preCalculateCommonItemValue(stageConfig) { }
 
 
 /**
@@ -69,12 +88,15 @@ let recruitToken = {
  */
 function calculatedItemValue(stageConfig) {
     //解构关卡自定义配置  经验书系数  龙门币系数  加工站爆率  自定义物品列表
-    const {expCoefficient, lmdCoefficient, workshopEliteMaterialByProductRate,workshopSkillSummaryByProductRate, customItem} = stageConfig
+    const { expCoefficient, lmdCoefficient, workshopEliteMaterialByProductRate, workshopSkillSummaryByProductRate, customItem } = stageConfig
 
-    //自定义物品map
+    /**
+     * 自定义物品价值表，key 为物品 ID，value 为物品价值
+     * @type {Map<string, number>}
+     */
     let customItemMap = new Map()
 
-    //将自定义物品列表转为一个map
+    // 将自定义物品列表转为一个map
     if (customItem) {
         for (const item of customItem) {
             customItemMap.set(item.itemId, item.itemValue)
@@ -87,25 +109,9 @@ function calculatedItemValue(stageConfig) {
 
     //将物品信息列表循环处理一下，写入到物品信息map
     for (let item of itemInfoList) {
-        const itemId = item.itemId
-        //这里处理经验书和龙门币的价值，根据经验书和龙门币系数计算价值
-        if (itemId === "2004") {
-            item.itemValue = baseLMDValue * expCoefficient * 2000
-        }
-        if (itemId === "2003") {
-            item.itemValue = baseLMDValue * expCoefficient * 1000
-        }
-        if (itemId === "2002") {
-            item.itemValue = baseLMDValue * expCoefficient * 400
-        }
-        if (itemId === "2001") {
-            item.itemValue = baseLMDValue * expCoefficient * 200
-        }
-        if (itemId === "4001") {
-            item.itemValue = baseLMDValue * lmdCoefficient
-        }
+        const itemId = item.itemId;
 
-        //迭代物品价值，  物品价值/对应最高效率关的理智转化率
+        //迭代物品价值，物品价值/对应最高效率关的理智转化率
         if (itemValueCorrectionTerm[itemId]) {
             // console.log(item.itemName, item.itemValue, '/', itemValueCorrectionTerm[itemId].correctionTerm)
             item.itemValue = item.itemValue / itemValueCorrectionTerm[itemId].correctionTerm
@@ -123,7 +129,7 @@ function calculatedItemValue(stageConfig) {
     //将白绿紫金物品通过加工站合成路径得出价值
     for (const table of COMPOSITE_TABLE) {
         //解构加工路径表   合成或拆解的物品id  判断拆解还是合成  合成路径
-        const {itemId, resolve, pathway} = table
+        const { itemId, resolve, pathway } = table
         //如果这个物品被自定义了，不再通过合成路径得到价值
         if (customItemMap.get(itemId)) {
             continue
@@ -172,10 +178,38 @@ function calculatedItemValue(stageConfig) {
     _calculatedCommonItemValue(stageConfig)
 
     function _calculatedCommonItemValue(stageConfig) {
-        // 至纯源石
-        const itemValue4002 = 135;
+        // 龙门币
+        const itemValue4001 = stageConfig.lmdCoefficient * baseLMDValue;
+        // EXP
+        const itemValueEXP = stageConfig.expCoefficient * baseEXPValue;
+        const itemValue2001 = itemValueEXP * 200;
+        const itemValue2002 = itemValueEXP * 400;
+        const itemValue2003 = itemValueEXP * 1000;
+        const itemValue2004 = itemValueEXP * 2000;
+        // 无人机
+        const itemValueBaseAp = itemValueEXP * 50 / 3;
+        // 赤金
+        const itemValue3003 = itemValueBaseAp * 24;
+
         // 合成玉
-        const itemValue4003 = itemValue4002 / 180;
+        let itemValue4003;
+        switch (stageConfig.orundumPricingStrategy) {
+            case "ORUNDUM_PRICING_ORININUM_FARMING_ORIROCK_CUBE":
+                itemValue4003 = (itemInfoMap.get('30012').itemValue * 2 + 1600 * itemValue4001 + 40 * itemValueBaseAp) / 10;
+                break;
+            case "ORUNDUM_PRICING_ORININUM_FARMING_DEVICE":
+                itemValue4003 = (itemInfoMap.get('30062').itemValue + 1000 * itemValue4001 + 40 * itemValueBaseAp) / 10;
+                break;
+            default:
+                itemValue4003 = stageConfig.orundumValue;
+        }
+        // 至纯源石
+        let itemValue4002;
+        if (stageConfig.originitePrimeCoefficient === Infinity) {
+            itemValue4002 = Infinity;
+        } else {
+            itemValue4002 = stageConfig.originitePrimeCoefficient * itemValue4003;
+        }
         // 寻访凭证
         const itemValue7003 = 600 * itemValue4003;
         // 十连寻访凭证
@@ -185,36 +219,61 @@ function calculatedItemValue(stageConfig) {
         // 高级凭证
         const itemValue4004 = 38 / 258 * itemValue7003;
         // 中坚寻访凭证
-        const itemValueClassicGacha = 216 / 38 * itemValue4004;
+        let itemValueClassicGacha;
+        if (stageConfig.kernalHeadhuntingPermitCoefficient === 0) {
+            itemValueClassicGacha = 0;
+        } else {
+            itemValueClassicGacha = stageConfig.kernalHeadhuntingPermitCoefficient * itemValue7003;
+        }
         // 十连中坚寻访凭证
         const itemValueClassicGacha10 = 10 * itemValueClassicGacha;
 
-        // 家具零件
-        const itemValue3401 = 0;
+        // 招聘许可
+        let itemValue7001 = 0;
+        if (itemValue4004 === Infinity) {
+            itemValue7001 = Infinity;
+        }
+        else {
+            for (const [rarity, recruitToken] of Object.entries(recruitTokenMap[stageConfig.recruitmentPermitPricingStrategy])) {
+                itemValue7001 += recruitRarity[rarity] * (recruitToken["4005"] * itemValue4005 + recruitToken["4004"] * itemValue4004);
+            }
+        }
         // 加急许可
-        const itemValue7002 = 0;
-
-        // 龙门币
-        const itemValueLMD = itemInfoMap.get('4001').itemValue;
-        // EXP
-        const itemValueEXP = itemInfoMap.get('2001').itemValue / 200;
-        // 无人机
-        const itemValueBaseAp = itemValueEXP * 50 / 3;
-        // 赤金
-        const itemValue3003 = itemValueBaseAp * 24;
+        let itemValue7002;
+        switch (stageConfig.expeditedPlanPricingStrategy) {
+            case "EXPEDITED_PLAN_PRICING_RECRUITMENT_PERMIT":
+                itemValue7002 = itemValue7001;
+                break;
+            default:
+                itemValue7002 = stageConfig.expeditedPlanValue;
+        }
+        // 家具零件
+        // TODO: 按 SK-5 定价
+        const itemValue3401 = stageConfig.furniturePartValue;
 
         // 采购凭证
-        const itemValue4006 = 30 * (1 - itemValueLMD * 12) / 21;
+        const itemValue4006 = 30 * (1 - itemValue4001 * 12) / 21;
         // 芯片助剂
         const itemValue32001 = itemValue4006 * 90;
         // 芯片
-        const chip1Value = 18 * (1 - itemValueLMD * 12);
+        const chip1Value = 18 * (1 - itemValue4001 * 12);
         // 芯片组
-        const chip2Value = 36 * (1 - itemValueLMD * 12);
-        // 双芯片，省略 1 秒制造站基础工时
-        const chip3Value = chip2Value * 2 + itemValue32001;
+        const chip2Value = 36 * (1 - itemValue4001 * 12);
+        // 双芯片
+        const chip3Value = chip2Value * 2 + itemValue32001 + 1 / 180 * itemValueBaseAp;
         // 模组数据块
-        const itemValueModUnlockToken = 120 * itemValue4006;
+        let itemValueModUnlockToken;
+        switch (stageConfig.modUnlockTokenPricingStrategy) {
+            case "MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE":
+                itemValueModUnlockToken = 120 * itemValue4006;
+                break;
+            case "MOD_UNLOCK_TOKEN_PRICING_DISTINCTION_CERTIFICATE":
+                itemValueModUnlockToken = 20 * itemValue4004;
+                break;
+            case "MOD_UNLOCK_TOKEN_PRICING_CUSTOM":
+                itemValueModUnlockToken = stageConfig.modUnlockTokenValue;
+                break;
+        }
         // 事相碎片
         const itemValueSTORYREVIEWCOIN = 20 * itemValue4006;
 
@@ -222,12 +281,12 @@ function calculatedItemValue(stageConfig) {
         // 因果
         const itemValueYinGuo = 10 / 9 * (1 - workshopEliteMaterialByProductRate) * t3workShopProductsValue / 36;
         // 碳素组
-        const itemValue3114 = 240 / 19 * itemValue3401 + 4 * itemValueYinGuo - 4000 / 19 * itemValueLMD;
+        const itemValue3114 = 240 / 19 * itemValue3401 + 4 * itemValueYinGuo - 4000 / 19 * itemValue4001;
         const itemValue3113 = 11 / 30 * itemValue3114 + 6 / 5 * itemValueYinGuo;
         const itemValue3112 = 11 / 30 * itemValue3113 + 3 / 5 * itemValueYinGuo;
 
         // 技巧概要·卷3
-        const itemValue3303 = (30 * (1 - itemValueLMD * 12)
+        const itemValue3303 = (30 * (1 - itemValue4001 * 12)
             / (2 + 3 / 2 * (1 + workshopSkillSummaryByProductRate) / 3 + 1.5 * (1 + workshopSkillSummaryByProductRate) ** 2 / 3 ** 2));
 
         // 技能概要·卷2
@@ -235,17 +294,9 @@ function calculatedItemValue(stageConfig) {
         // 技能概要·卷1
         const itemValue3301 = (1 + workshopSkillSummaryByProductRate) * itemValue3302 / 3;
 
-        // 招聘许可
-        let itemValue7001 = 0;
-        for (const rarity in recruitToken) {
-            itemValue7001 += recruitRarity[rarity] * (recruitToken[rarity]["4005"] * itemValue4005 + recruitToken[rarity]["4004"] * itemValue4004);
-        }
 
-        // 合成玉（搓玉）
-        const itemValue4003sp = (itemInfoMap.get('30012').itemValue * 2 + 1600 * itemValueLMD + 40 * itemValueBaseAp) / 10;
-
-        itemInfoMap.get("4002").itemValue = itemValue4002;
         itemInfoMap.get("4003").itemValue = itemValue4003;
+        itemInfoMap.get("4002").itemValue = itemValue4002;
         itemInfoMap.get("7003").itemValue = itemValue7003;
         itemInfoMap.get("7004").itemValue = itemValue7004;
         itemInfoMap.get("4005").itemValue = itemValue4005;
@@ -253,7 +304,12 @@ function calculatedItemValue(stageConfig) {
         itemInfoMap.get("classic_gacha").itemValue = itemValueClassicGacha;
         itemInfoMap.get("classic_gacha_10").itemValue = itemValueClassicGacha10;
         itemInfoMap.get("3401").itemValue = itemValue3401;
-        // itemInfoMap.get("7002").itemValue = itemValue7002;
+        itemInfoMap.get("7002").itemValue = itemValue7002;
+        itemInfoMap.get("4001").itemValue = itemValue4001;
+        itemInfoMap.get("2001").itemValue = itemValue2001;
+        itemInfoMap.get("2002").itemValue = itemValue2002;
+        itemInfoMap.get("2003").itemValue = itemValue2003;
+        itemInfoMap.get("2004").itemValue = itemValue2004;
         itemInfoMap.get("base_ap").itemValue = itemValueBaseAp;
         itemInfoMap.get("3003").itemValue = itemValue3003;
         itemInfoMap.get("4006").itemValue = itemValue4006;
@@ -267,7 +323,6 @@ function calculatedItemValue(stageConfig) {
         itemInfoMap.get("3302").itemValue = itemValue3302;
         itemInfoMap.get("3301").itemValue = itemValue3301;
         itemInfoMap.get("7001").itemValue = itemValue7001;
-        itemInfoMap.get("4003sp").itemValue = itemValue4003sp;
 
         const chip1 = ['3211', '3221', '3231', '3241', '3251', '3261', '3271', '3281']
         const chip2 = ['3212', '3222', '3232', '3242', '3252', '3262', '3272', '3282']
@@ -282,7 +337,9 @@ function calculatedItemValue(stageConfig) {
         for (const chipId of chip3) {
             itemInfoMap.get(chipId).itemValue = chip3Value;
         }
-
+        // for (const [itemId, item] of itemInfoMap) {
+        //     console.log(itemId, item.itemName, item.itemValue)
+        // }
     }
 
 
@@ -313,7 +370,7 @@ function calculatedItemValue(stageConfig) {
         for (const [rarity, group] of collect) {
             let expectValue = 0.0
             for (const item of group) {
-                const {itemValue, itemName, weight} = item
+                const { itemValue, itemName, weight } = item
                 expectValue += itemValue * weight
                 // console.log('+=',itemName+'='+itemValue+'*'+weight,'=',expectValue)
             }
@@ -349,7 +406,7 @@ async function getItemValueCorrectionTerm(stageConfig) {
     for (const [stageId, list] of stageDropCollect) {
 
         //关卡消耗理智，关卡代号，关卡类型
-        const {apCost, stageCode, stageType} = list[0]
+        const { apCost, stageCode, stageType } = list[0]
 
         if (['MAIN', 'ACT_PERM'].includes(stageType)) {
             //如果不使用活动关定价则跳出循环
@@ -403,7 +460,7 @@ async function getItemValueCorrectionTerm(stageConfig) {
         for (const drop of list) {
 
             //解构出物品id，掉落次数，样本数
-            const {itemId, quantity, times} = drop
+            const { itemId, quantity, times } = drop
 
             // 从物品表里面取出对应掉落物的信息
             const itemInfo = itemMap.get(itemId);
@@ -414,7 +471,7 @@ async function getItemValueCorrectionTerm(stageConfig) {
             }
 
             //从物品信息中解构出物品价值
-            const {itemValue, itemName} = itemInfo;
+            const { itemValue, itemName } = itemInfo;
 
             //计算物品掉率
             const knockRating = quantity / times
@@ -461,7 +518,7 @@ async function getItemValueCorrectionTerm(stageConfig) {
         let seriesInfo = itemSeriesInfoByItemId.get(mainItemId)
 
         //物品系列的id和名称
-        const {seriesId, seriesName} = seriesInfo
+        const { seriesId, seriesName } = seriesInfo
 
         //物品系列的迭代值
         const seriesCorrectionTerm = {
@@ -528,7 +585,7 @@ async function getItemValueCorrectionTerm(stageConfig) {
 async function getCustomItemList(stageConfig) {
 
     //获取根据关卡id分类的关卡掉落数据
-    stageDropCollect = await getStageDropCollect(stageConfig,true)
+    stageDropCollect = await getStageDropCollect(stageConfig, true)
 
     const customItem = stageConfig.customItem
 
@@ -538,7 +595,7 @@ async function getCustomItemList(stageConfig) {
     //将自定义物品列表转为一个map
     if (customItem) {
         for (const item of customItem) {
-            const {itemId, itemValue} = item
+            const { itemId, itemValue } = item
             customItemMap.set(itemId, itemValue)
         }
     }
@@ -550,7 +607,7 @@ async function getCustomItemList(stageConfig) {
         // console.table(itemList)
         calculatedItemValue(stageConfig)
 
-        const {nextItemCorrectionTerm} = await getItemValueCorrectionTerm(stageConfig);
+        const { nextItemCorrectionTerm } = await getItemValueCorrectionTerm(stageConfig);
 
         //是否迭代完成的标记
         let completionFlag = true;
@@ -582,4 +639,4 @@ async function getCustomItemList(stageConfig) {
 
 export {
     getCustomItemList
-}
+};

--- a/src/utils/item/itemValue.js
+++ b/src/utils/item/itemValue.js
@@ -1,59 +1,88 @@
 import { getStageDropCollect } from "@/plugins/indexedDB/penguinData.js";
 import ITEM_INFO from "@/static/json/material/item_info.json";
+import ITEM_SERIES_INFO from '/src/static/json/material/item_series_info.json';
 import COMPOSITE_TABLE from '/src/static/json/material/composite_table.v2.json';
 import { itemSeriesInfoByItemId } from "/src/utils/item/itemSeries.js";
 
+/**
+ * @typedef {Object} ItemInfo
+ * @property {string} itemId - 物品 ID
+ * @property {string} itemName - 物品名称
+ * @property {number} itemValue - 物品价值
+ * @property {number} rarity - 物品稀有度
+ * @property {number} weight - 物品权重
+ */
 
-//加工站每级期望产出理智初始值
-let workShopProducts = {
-    t1: 1.9622015949221407,
-    t2: 5.853670784766422,
-    t3: 24.578868967312253,
-    t4: 79.8592285162492
+/**
+ * @typedef {Object} StageDropInfo
+ * @property {string} stageId - 作战 ID
+ * @property {string} stageCode - 作战名称
+ * @property {number} apCost - 理智消耗
+ * @property {number} quantity - 掉落数
+ * @property {number} times - 样本数
+ */
+
+
+/**
+ * 判断物品是否为精英材料
+ * 直接使用物品 ID 判断，不一定准确
+ * @param {string} item_id 物品 ID
+ * @return {boolean} 是否为精英材料
+ */
+function isEliteMaterial(item_id) {
+    return /^3[01]\d{3}/.test(item_id);
 }
 
-//每种精英物品的初始迭代值
-let itemValueCorrectionTerm = {
-    30013: { correctionTerm: 1.00000137324044, itemName: '固源岩组' },
-    30023: { correctionTerm: 1.0000040009822255, itemName: '糖组' },
-    30033: { correctionTerm: 1.0000019925398336, itemName: '聚酸酯组' },
-    30043: { correctionTerm: 0.9999483750088554, itemName: '异铁组' },
-    30053: { correctionTerm: 1.0000022954075312, itemName: '酮凝集组' },
-    30063: { correctionTerm: 1.0000013169421755, itemName: '全新装置' },
-    30073: { correctionTerm: 0.9999649132885954, itemName: '扭转醇' },
-    30083: { correctionTerm: 1.000002240727396, itemName: '轻锰矿' },
-    30093: { correctionTerm: 1.0000022806201772, itemName: '研磨石' },
-    30103: { correctionTerm: 1.0000130948559616, itemName: 'RMA70-12' },
-    31013: { correctionTerm: 0.9999904276257087, itemName: '凝胶' },
-    31023: { correctionTerm: 1.0000248495124442, itemName: '炽合金' },
-    31033: { correctionTerm: 1.00000158366126, itemName: '晶体元件' },
-    31043: { correctionTerm: 0.999997836003829, itemName: '半自然溶剂' },
-    31053: { correctionTerm: 1.000006210539448, itemName: '化合切削液' },
-    31063: { correctionTerm: 0.9999981294168673, itemName: '转质盐组' },
-    31073: { correctionTerm: 1.0001889176671603, itemName: '褐素纤维' },
-    31083: { correctionTerm: 0.9996130718228801, itemName: '环烃聚质' },
-    31093: { correctionTerm: 0.9996130718228801, itemName: '类凝结核' }
+
+/**
+ * 物品信息列表，包含物品id、名称、价值、稀有度、权重等信息
+ * @type {Array<ItemInfo>}
+ */
+const itemInfoList = ITEM_INFO.filter(e => e.cardNum < 100);
+
+/**
+ * 物品信息映射，key 为物品 ID，value 为物品信息
+ * @type {Map<string, ItemInfo>}
+ */
+const itemInfoMap = new Map(itemInfoList.map(item => [item.itemId, item]));
+
+
+/**
+ * 加工产出副产品时，各种物品作为副产品的概率
+ * key 为物品稀有度，value 为副产品概率映射
+ * @type {Map<number, Map<string, number>>}
+ */
+const workshopByproductWeightMap = new Map([
+    [1, new Map()],
+    [2, new Map()],
+    [3, new Map()],
+    [4, new Map()],
+]);
+for (const item of itemInfoList) {
+    if (item.weight === 0) {
+        continue;  // 通过副产品排除非可加工物品
+    }
+    workshopByproductWeightMap.get(item.rarity).set(item.itemId, item.weight);
 }
 
-//物品信息列表
-let itemInfoList = ITEM_INFO.filter(e => e.cardNum < 100)
 
-//按关卡id分组的关卡掉落数据
-let stageDropCollect = void 0
+// 基础龙门币价值、基础 EXP 价值
+const baseLMDValue = 36 / 10000;
+const baseEXPValue = 36 / 10000;
 
-//基础龙门币价值（按CE6  10000龙门币=36理智）
-const baseLMDValue = 0.0036
-const baseEXPValue = 0.0036
-
-// 公开招募结果的星级概率分布
+/**
+ * 公开招募结果的星级概率分布
+ * 来源：教捐
+ * 详见物品价值算法文档 (https://ark.yituliu.cn/docs/item-value-algorithm#%E6%8B%9B%E8%81%98%E8%AE%B8%E5%8F%AF)
+ */
 const recruitRarity = {
     "3": 0.7882,
     "4": 0.2027,
     "5": 0.0069,
     "6": 0.0022,
-}
+};
 
-// 公开招募获得的凭证数量
+/** 公开招募获得的凭证数量 */
 const recruitTokenMap = {
     "RECRUITMENT_PERMIT_PRICING_3_4": {
         "3": { "4005": 10, "4004": 0 },
@@ -72,112 +101,333 @@ const recruitTokenMap = {
         "4": { "4005": 30, "4004": 1 },
         "5": { "4005": 0, "4004": 13 },
         "6": { "4005": 0, "4004": 25 },
-    }
-}
-
-/**
- *
- * @param {*} stageConfig 关卡自定义配置
- */
-function preCalculateCommonItemValue(stageConfig) { }
+    },
+};
 
 
 /**
- * 计算物品价值
- * @param stageConfig 关卡自定义配置
+ * 根据自定义配置计算物品价值表
+ * @param stageConfig 自定义参数
+ * @return {Promise<Array<ItemInfo>>}
  */
-function calculatedItemValue(stageConfig) {
-    //解构关卡自定义配置  经验书系数  龙门币系数  加工站爆率  自定义物品列表
-    const { expCoefficient, lmdCoefficient, workshopEliteMaterialByProductRate, workshopSkillSummaryByProductRate, customItem } = stageConfig
+async function getCustomItemList(stageConfig, maxIteration = 50, tolerance = 0.000001) {
 
     /**
-     * 自定义物品价值表，key 为物品 ID，value 为物品价值
+     * 作战效率和主产物（仅包含定价作战集中的作战）
+     * key 为作战 ID，value 为作战效率和主产物 ID
+     * @type {Map<string, { stageEfficiency: number, mainItemId: string }>}
+     */
+    const stageDropInfoMap = new Map();
+
+    /**
+     * 每系列材料的最高效率作战的作战效率
+     * key 为物品系列 ID，
+     * value 为定价作战集中，以该系列材料为主产物的最高效率作战和对应的效率
+     * @type {Map<string, { stageId: string, stageEfficiency: number }>}
+     */
+    const maxStageEfficiencyMap = new Map(ITEM_SERIES_INFO.map(series => [series.seriesId, { stageId: "", stageEfficiency: -Infinity }]));
+
+
+    // 步骤 1. 确定定价作战集和自定义物品价值
+
+    /**
+     * 按作战 ID 分组的作战掉落数据
+     * - 已排除样本数小于 `stageConfig.sampleSize` 的作战
+     * - 已排除 `stageConfig.stageBlacklist` 中的作战
+     * - 无论 `stageConfig.useActivityStage` 和 `stageConfig.useActivityAverageStage` 真假，总是包含活动作战，需要进一步手动排除
+     * @type {Map<string, Array<StageDropInfo>>}
+     */
+    const stageDropCollect = await getStageDropCollect(stageConfig, true);
+    /**
+     * 定价作战集
+     * 从 `stageDropCollect` 中筛选出符合定价作战集条件的作战
+     * - 已排除样本数小于 `stageConfig.sampleSize` 的作战
+     * - 已排除 `stageConfig.stageBlacklist` 中的作战
+     * - 若 `stageConfig.useActivityStage` 为假，则已排除所有活动作战
+     * - 若 `stageConfig.useActivityAverageStage` 为假，则已排除所有活动平均作战
+     */
+    const stageDropCollectForPricing = new Map();
+    for (const [stageId, dropList] of stageDropCollect) {
+        // 提取关卡消耗理智、关卡代号、关卡类型
+        const { apCost, stageType } = dropList[0];
+        if (['MAIN', 'ACT_PERM'].includes(stageType)) {
+            // 主线和常驻活动关卡总是包含在定价作战集中
+        }
+        if (['ACT', 'ACT_REP'].includes(stageType) && !stageConfig.useActivityStage) {
+            continue;  // 如果不使用活动作战定价则跳过
+        }
+        if ('YTL_VIRTUAL' === stageType && !stageConfig.useActivityAverageStage) {
+            continue;  // 如果不使用活动平均作战定价则跳过
+        }
+        stageDropCollectForPricing.set(stageId, dropList);
+    }
+
+    /**
+     * 自定义精英材料价值映射，key 为物品 ID，value 为物品价值
      * @type {Map<string, number>}
      */
-    let customItemMap = new Map()
+    const customEliteMaterialValueMap = new Map(stageConfig.customItem.map(item => [item.itemId, item.itemValue]));
 
-    // 将自定义物品列表转为一个map
-    if (customItem) {
-        for (const item of customItem) {
-            customItemMap.set(item.itemId, item.itemValue)
+
+    // 步骤 2. 设定初始值
+    // - 除已经自定义的蓝材料外，给每种其他蓝材料的价值分别设定初始值。
+    // - 给加工绿、蓝、紫、金材料时副产品价值的期望分别设定初始值。
+
+    /**
+     * 物品价值映射，key 为物品 ID，value 为物品价值
+     * - 精英材料初始价值设为 3 ** rarity，非精英材料初始价值设为 0
+     * - 精英材料的初始价值不能太小，否则迭代时会有很多作战的主产物为非精英材料，导致这部分作战永远不会被考虑
+     * @type {Map<string, number>}
+     */
+    const itemValueMap = new Map(itemInfoList.map(({ itemId, rarity }) => [itemId, isEliteMaterial(itemId) ? 3 ** rarity : 0]));
+
+    /**
+     * 白、绿、蓝、紫副产品价值的期望，也即一个随机材料的价值
+     * key 为副产品稀有度，value 为期望值
+     * - 初始值设为 3 ** rarity
+     * @type {Map<number, number>}
+     */
+    const workshopByproductExpectedValue = new Map([
+        [1, 3],
+        [2, 9],
+        [3, 27],
+        [4, 81],
+    ]);
+
+
+    // 重复步骤 3、4、5、6、7，迭代计算物品价值，一般 10 次之内就能得出结果
+    for (let i = 0; i < maxIteration; i++) {
+        console.log(`第${i + 1}次迭代`);
+
+        // 步骤 7. 计算非精英材料的价值
+        calculateCommonItemValue();
+        // console.log("itemValueMap", Object.fromEntries(itemValueMap));
+
+        // 步骤 3. 计算所有精英材料的价值
+        calculateEliteMaterialValueFromT3();
+        // console.log("itemValueMap", Object.fromEntries(itemValueMap));
+
+        // 步骤 4. 计算副产品价值的期望
+        calculateWorkshopByproductExpectedValue();
+        // console.log("workshopByproductExpectedValue", Object.fromEntries(workshopByproductExpectedValue));
+
+        // 步骤 5. 计算作战期望掉落物品的总价值
+        calculateStageDropExpectedValue();
+        // console.log("stageDropInfoMap", Object.fromEntries(stageDropInfoMap));
+
+        // 步骤 6. 修正蓝材料的价值
+        updateT3EliteMaterialValue();
+        console.log("maxStageEfficiencyMap", Object.fromEntries(maxStageEfficiencyMap));
+
+        // 检查是否满足停机条件
+        if (checkCompletion(tolerance)) {
+            // 如果满足停机条件，结束迭代
+            break;
         }
     }
 
-
-    //物品信息map 以物品id为key
-    let itemInfoMap = new Map()
-
-    //将物品信息列表循环处理一下，写入到物品信息map
-    for (let item of itemInfoList) {
-        const itemId = item.itemId;
-
-        //迭代物品价值，物品价值/对应最高效率关的理智转化率
-        if (itemValueCorrectionTerm[itemId]) {
-            // console.log(item.itemName, item.itemValue, '/', itemValueCorrectionTerm[itemId].correctionTerm)
-            item.itemValue = item.itemValue / itemValueCorrectionTerm[itemId].correctionTerm
-        }
-
-        //如果物品被自定义价值了，将自定义价值强制写入
-        if (customItemMap.get(itemId)) {
-            item.itemValue = customItemMap.get(itemId)
-        }
-
-        //写入物品信息map
-        itemInfoMap.set(itemId, item)
+    // 把物品信息列表中的物品价值更新为计算后的值
+    for (const item of itemInfoList) {
+        item.itemValue = itemValueMap.get(item.itemId);
     }
 
-    //将白绿紫金物品通过加工站合成路径得出价值
-    for (const table of COMPOSITE_TABLE) {
-        //解构加工路径表   合成或拆解的物品id  判断拆解还是合成  合成路径
-        const { itemId, resolve, pathway } = table
-        //如果这个物品被自定义了，不再通过合成路径得到价值
-        if (customItemMap.get(itemId)) {
-            continue
-        }
+    return itemInfoList;
 
-        //通过id得到对应的物品信息
-        let item = itemInfoMap.get(itemId);
+    // ========== 函数结束 ==========
 
-        //物品等级
-        const rarity = item.rarity
+    /**
+     * 步骤 3. 计算所有精英材料的价值
+     * 在已知所有蓝材料价值的情况下，根据加工配方，计算白、绿、紫、金材料的价值。
+     * 思想：所有精英材料配方的消耗总价值等于产出总价值
+     *
+     * 函数将修改 `itemValueMap` 中的白、绿、紫、金材料价值。
+     */
+    function calculateEliteMaterialValueFromT3() {
+        /** 龙门币价值 */
+        const lmdValue = itemValueMap.get("4001");
 
-        //物品新价值
-        let newValue = 0.0
+        for (const table of COMPOSITE_TABLE) {
+            // 解构加工路径表：合成或拆解的物品id、判断拆解还是合成、合成路径
+            const { itemId, resolve, pathway } = table;
 
-        if (resolve) {
-            //灰，绿色品质是向下拆解   灰，绿色物品 = （蓝物品价值 + 副产物 - 龙门币）/合成蓝物品的所需灰绿物品数量
-            const expectProductsValue = workShopProducts[`t${rarity}`] * workshopEliteMaterialByProductRate
-            for (const cost of pathway) {
-                const rawItem = itemInfoMap.get(cost.itemId)
-                newValue = (rawItem.itemValue + expectProductsValue - 0.36 * lmdCoefficient * rarity) / cost.count
-                // console.log(item.itemName + '=' + rawItem.itemName + '=(' + rawItem.itemValue + "+" + expectProductsValue + '-' + (0.36 * rarity) + ')/' + cost.count + '=' + newValue)
+            // 如果这个物品被自定义了，不再通过合成路径得到价值
+            if (customEliteMaterialValueMap.has(itemId)) {
+                continue;
             }
-        } else {
-            //紫，金色品质是向上合成    紫，金色物品 =  合成所需蓝物品价值之和  + 龙门币 - 副产物
-            const expectProductsValue = workShopProducts[`t${rarity - 1}`] * workshopEliteMaterialByProductRate
-            for (const cost of pathway) {
-                const rawItem = itemInfoMap.get(cost.itemId)
-                newValue += rawItem.itemValue * cost.count
-                // console.log(item.itemName + '=' + rawItem.itemName + '*' + cost.count + '=' + newValue)
+
+            // 通过id得到对应的物品信息
+            const rarity = itemInfoMap.get(itemId).rarity;
+
+            // 物品新价值
+            let newValue = 0.0;
+
+            if (resolve) {
+                // 灰、绿色品质是向下拆解   灰、绿色物品 = （蓝物品价值 + 副产品 - 龙门币）/合成蓝物品的所需灰绿物品数量
+                const expectProductsValue = workshopByproductExpectedValue.get(rarity) * stageConfig.workshopEliteMaterialByProductRate;
+                for (const cost of pathway) {
+                    const rawItemValue = itemValueMap.get(cost.itemId);
+                    newValue = (rawItemValue + expectProductsValue - 100 * rarity * lmdValue) / cost.count;
+                }
+            } else {
+                // 紫、金色品质是向上合成    紫、金色物品 = 合成所需蓝物品价值之和 + 龙门币 - 副产品
+                const expectProductsValue = workshopByproductExpectedValue.get(rarity - 1) * stageConfig.workshopEliteMaterialByProductRate;
+                for (const cost of pathway) {
+                    const rawItemValue = itemValueMap.get(cost.itemId);
+                    newValue += rawItemValue * cost.count;
+                }
+                newValue += 100 * (rarity - 1) * lmdValue - expectProductsValue;
             }
 
-            newValue = newValue + 0.36 * lmdCoefficient * (rarity - 1) - expectProductsValue
-            // console.log(item.itemName + '=' + (0.36 * (rarity - 1)) + '-' + expectProductsValue + '=' + newValue)
-
+            // 更新物品新价值
+            itemValueMap.set(itemId, newValue);
         }
-        // console.log(newValue)
-        // console.log(item)
-
-        //更新物品新价值
-        item.itemValue = newValue
-        // console.log(newValue)
     }
 
-    _getWorkShopProductValue(itemInfoList)
+    /**
+     * 步骤 4. 计算副产品价值的期望
+     * 使用上一步计算出的所有精英材料的价值，计算加工绿、蓝、紫、金材料时副产品价值的期望。
+     *
+     * 函数将修改 `workshopByproductExpectedValue`。
+     */
+    function calculateWorkshopByproductExpectedValue() {
 
-    _calculatedCommonItemValue(stageConfig)
+        // 计算按物品等级分类后的加工站各级物品副产品期望产出
+        for (const [rarity, group] of workshopByproductWeightMap) {
+            let expectValue = 0.0;
+            for (const [itemId, weight] of group) {
+                expectValue += itemValueMap.get(itemId) * weight;
+            }
+            // 更新加工站各级物品副产品期望产出
+            workshopByproductExpectedValue.set(rarity, expectValue);
+        }
+    }
 
-    function _calculatedCommonItemValue(stageConfig) {
+    /**
+     * 步骤 5. 对于每个作战，计算作战期望掉落物品的总价值，进而计算作战效率。
+     * 作战效率 = 作战期望掉落物品的总价值 ÷ 作战的理智消耗
+     *
+     * 函数将修改 `stageDropInfoMap`。
+     */
+    function calculateStageDropExpectedValue() {
+
+        // 循环关卡的物品掉落集合，每个集合是根据关卡id分组的
+        for (const [stageId, dropList] of stageDropCollectForPricing) {
+
+            // 提取关卡消耗理智
+            const { apCost } = dropList[0];
+
+            // 关卡期望产出总理智
+            let stageExpectedOutput = 0;
+
+            // 主产物物品id
+            // 这里主产物定义为价值占比最高的物品
+            let mainItemId;
+            // 最高的单项物品产出价值
+            let maxValue = -Infinity;
+
+            // 循环关卡的物品掉落集合
+            for (const drop of dropList) {
+
+                // 解构出物品id，掉落次数，样本数
+                const { itemId, quantity, times } = drop;
+
+                // 从物品表里面取出对应掉落物的信息
+                const itemValue = itemValueMap.get(itemId);
+
+                // 如果查不到物品信息则跳过
+                if (!itemValue) {
+                    continue;
+                }
+
+                // 计算物品掉率
+                const knockRating = quantity / times;
+
+                // 计算单项物品期望产出价值
+                const expectedOutput = knockRating * itemValue;
+
+                // 比较单项物品最大产出，最大的为主产物
+                if (expectedOutput > maxValue) {
+                    mainItemId = itemId;
+                    maxValue = expectedOutput;
+                }
+
+                // 计算关卡期望产出总理智
+                stageExpectedOutput += expectedOutput;
+            }
+
+            stageDropInfoMap.set(stageId, {
+                stageEfficiency: stageExpectedOutput / apCost,
+                mainItemId: mainItemId,
+            });
+        }
+    }
+
+    /**
+     * 步骤 6. 修正蓝材料的价值
+     *
+     * 思想：
+     * 1. 定价作战集中的所有作战效率 ≤ 1；
+     * 2. 对于每一系列材料，在定价作战集中至少存在 1 个以该系列材料为主产物且效率等于 1 的作战。
+     *
+     * 固定一类材料，在定价作战集中寻找以该系列材料为主产物的所有作战，取其中作战效率最高的那个作战，作战效率记为 E。然后把对应的蓝材料的价值进行修正，将对应蓝材料的价值除以 E，得到新的价值。
+     * 这个步骤需要对每系列材料都做一遍（除了已经在步骤 1 自定义价值的材料）。
+     *
+     * 函数将修改 `maxStageEfficiencyMap` 与 `itemValueMap` 中的蓝材料价值。
+     */
+    function updateT3EliteMaterialValue() {
+
+        // 先清空 maxStageEfficiencyMap
+        for (const seriesId of maxStageEfficiencyMap.keys()) {
+            maxStageEfficiencyMap.set(seriesId, { stageId: "", stageEfficiency: -Infinity });
+        }
+
+        // 遍历所有作战
+        for (const [stageId, { stageEfficiency, mainItemId }] of stageDropInfoMap) {
+
+            // 查询这个关卡的主产物是否是精英材料
+            if (!itemSeriesInfoByItemId.has(mainItemId)) {
+                continue;  // 如果不是精英材料则跳过
+            }
+
+            // 获取精英材料对应系列的信息  如凝胶系为[凝胶、聚合凝胶]
+            const seriesInfo = itemSeriesInfoByItemId.get(mainItemId);
+
+            // 物品系列的id和名称
+            const { seriesId } = seriesInfo;
+
+            // 该系列材料的最高作战效率
+            const currentMaxStageEfficiency = maxStageEfficiencyMap.get(seriesId).stageEfficiency;
+
+            if (stageEfficiency > currentMaxStageEfficiency) {
+                // 如果当前作战效率大于该系列材料的最高效率，则更新最高效率
+                maxStageEfficiencyMap.set(seriesId, { stageId, stageEfficiency });
+            }
+        }
+
+        // 更新蓝材料的价值
+        for (const [seriesId, { stageId, stageEfficiency }] of maxStageEfficiencyMap) {
+
+            // 获取该系列蓝材料的物品 ID，蓝材料物品 ID 就是系列 ID
+            const itemIdT3 = seriesId;
+
+            // 获取该系列蓝材料之前的价值
+            const itemValueT3 = itemValueMap.get(itemIdT3);
+
+            // 更新蓝材料的价值
+            itemValueMap.set(itemIdT3, itemValueT3 / stageEfficiency);
+        }
+
+        // 将自定义精英材料价值写入物品价值映射
+        for (const [itemId, itemValue] of customEliteMaterialValueMap) {
+            itemValueMap.set(itemId, itemValue);
+        }
+    }
+
+
+    /**
+     * 步骤 7. 计算非精英材料的价值
+     */
+    function calculateCommonItemValue() {
         // 龙门币
         const itemValue4001 = stageConfig.lmdCoefficient * baseLMDValue;
         // EXP
@@ -195,11 +445,9 @@ function calculatedItemValue(stageConfig) {
         let itemValue4003;
         switch (stageConfig.orundumPricingStrategy) {
             case "ORUNDUM_PRICING_ORININUM_FARMING_ORIROCK_CUBE":
-                itemValue4003 = (itemInfoMap.get('30012').itemValue * 2 + 1600 * itemValue4001 + 40 * itemValueBaseAp) / 10;
-                break;
+                itemValue4003 = (itemValueMap.get("30012") * 2 + 1600 * itemValue4001 + 40 * itemValueBaseAp) / 10; break;
             case "ORUNDUM_PRICING_ORININUM_FARMING_DEVICE":
-                itemValue4003 = (itemInfoMap.get('30062').itemValue + 1000 * itemValue4001 + 40 * itemValueBaseAp) / 10;
-                break;
+                itemValue4003 = (itemValueMap.get("30062") + 1000 * itemValue4001 + 40 * itemValueBaseAp) / 10; break;
             default:
                 itemValue4003 = stageConfig.orundumValue;
         }
@@ -242,8 +490,7 @@ function calculatedItemValue(stageConfig) {
         let itemValue7002;
         switch (stageConfig.expeditedPlanPricingStrategy) {
             case "EXPEDITED_PLAN_PRICING_RECRUITMENT_PERMIT":
-                itemValue7002 = itemValue7001;
-                break;
+                itemValue7002 = itemValue7001; break;
             default:
                 itemValue7002 = stageConfig.expeditedPlanValue;
         }
@@ -265,21 +512,18 @@ function calculatedItemValue(stageConfig) {
         let itemValueModUnlockToken;
         switch (stageConfig.modUnlockTokenPricingStrategy) {
             case "MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE":
-                itemValueModUnlockToken = 120 * itemValue4006;
-                break;
+                itemValueModUnlockToken = 120 * itemValue4006; break;
             case "MOD_UNLOCK_TOKEN_PRICING_DISTINCTION_CERTIFICATE":
-                itemValueModUnlockToken = 20 * itemValue4004;
-                break;
+                itemValueModUnlockToken = 20 * itemValue4004; break;
             case "MOD_UNLOCK_TOKEN_PRICING_CUSTOM":
-                itemValueModUnlockToken = stageConfig.modUnlockTokenValue;
-                break;
+                itemValueModUnlockToken = stageConfig.modUnlockTokenValue; break;
         }
         // 事相碎片
         const itemValueSTORYREVIEWCOIN = 20 * itemValue4006;
 
-        const t3workShopProductsValue = workShopProducts.t3;
+        const t3workShopProductsValue = workshopByproductExpectedValue.get(3);
         // 因果
-        const itemValueYinGuo = 10 / 9 * (1 - workshopEliteMaterialByProductRate) * t3workShopProductsValue / 36;
+        const itemValueYinGuo = 10 / 9 * (1 - stageConfig.workshopEliteMaterialByProductRate) * t3workShopProductsValue / 36;
         // 碳素组
         const itemValue3114 = 240 / 19 * itemValue3401 + 4 * itemValueYinGuo - 4000 / 19 * itemValue4001;
         const itemValue3113 = 11 / 30 * itemValue3114 + 6 / 5 * itemValueYinGuo;
@@ -287,356 +531,71 @@ function calculatedItemValue(stageConfig) {
 
         // 技巧概要·卷3
         const itemValue3303 = (30 * (1 - itemValue4001 * 12)
-            / (2 + 3 / 2 * (1 + workshopSkillSummaryByProductRate) / 3 + 1.5 * (1 + workshopSkillSummaryByProductRate) ** 2 / 3 ** 2));
+            / (2 + 3 / 2 * (1 + stageConfig.workshopSkillSummaryByProductRate) / 3 + 1.5 * (1 + stageConfig.workshopSkillSummaryByProductRate) ** 2 / 3 ** 2));
 
         // 技能概要·卷2
-        const itemValue3302 = (1 + workshopSkillSummaryByProductRate) * itemValue3303 / 3;
+        const itemValue3302 = (1 + stageConfig.workshopSkillSummaryByProductRate) * itemValue3303 / 3;
         // 技能概要·卷1
-        const itemValue3301 = (1 + workshopSkillSummaryByProductRate) * itemValue3302 / 3;
+        const itemValue3301 = (1 + stageConfig.workshopSkillSummaryByProductRate) * itemValue3302 / 3;
 
+        // 回写物品价值
+        itemValueMap.set("4003", itemValue4003);
+        itemValueMap.set("4002", itemValue4002);
+        itemValueMap.set("7003", itemValue7003);
+        itemValueMap.set("7004", itemValue7004);
+        itemValueMap.set("4005", itemValue4005);
+        itemValueMap.set("4004", itemValue4004);
+        itemValueMap.set("classic_gacha", itemValueClassicGacha);
+        itemValueMap.set("classic_gacha_10", itemValueClassicGacha10);
+        itemValueMap.set("3401", itemValue3401);
+        itemValueMap.set("7002", itemValue7002);
+        itemValueMap.set("4001", itemValue4001);
+        itemValueMap.set("2001", itemValue2001);
+        itemValueMap.set("2002", itemValue2002);
+        itemValueMap.set("2003", itemValue2003);
+        itemValueMap.set("2004", itemValue2004);
+        itemValueMap.set("base_ap", itemValueBaseAp);
+        itemValueMap.set("3003", itemValue3003);
+        itemValueMap.set("4006", itemValue4006);
+        itemValueMap.set("32001", itemValue32001);
+        itemValueMap.set("mod_unlock_token", itemValueModUnlockToken);
+        itemValueMap.set("STORY_REVIEW_COIN", itemValueSTORYREVIEWCOIN);
+        itemValueMap.set("3114", itemValue3114);
+        itemValueMap.set("3113", itemValue3113);
+        itemValueMap.set("3112", itemValue3112);
+        itemValueMap.set("3303", itemValue3303);
+        itemValueMap.set("3302", itemValue3302);
+        itemValueMap.set("3301", itemValue3301);
+        itemValueMap.set("7001", itemValue7001);
 
-        itemInfoMap.get("4003").itemValue = itemValue4003;
-        itemInfoMap.get("4002").itemValue = itemValue4002;
-        itemInfoMap.get("7003").itemValue = itemValue7003;
-        itemInfoMap.get("7004").itemValue = itemValue7004;
-        itemInfoMap.get("4005").itemValue = itemValue4005;
-        itemInfoMap.get("4004").itemValue = itemValue4004;
-        itemInfoMap.get("classic_gacha").itemValue = itemValueClassicGacha;
-        itemInfoMap.get("classic_gacha_10").itemValue = itemValueClassicGacha10;
-        itemInfoMap.get("3401").itemValue = itemValue3401;
-        itemInfoMap.get("7002").itemValue = itemValue7002;
-        itemInfoMap.get("4001").itemValue = itemValue4001;
-        itemInfoMap.get("2001").itemValue = itemValue2001;
-        itemInfoMap.get("2002").itemValue = itemValue2002;
-        itemInfoMap.get("2003").itemValue = itemValue2003;
-        itemInfoMap.get("2004").itemValue = itemValue2004;
-        itemInfoMap.get("base_ap").itemValue = itemValueBaseAp;
-        itemInfoMap.get("3003").itemValue = itemValue3003;
-        itemInfoMap.get("4006").itemValue = itemValue4006;
-        itemInfoMap.get("32001").itemValue = itemValue32001;
-        itemInfoMap.get("mod_unlock_token").itemValue = itemValueModUnlockToken;
-        itemInfoMap.get("STORY_REVIEW_COIN").itemValue = itemValueSTORYREVIEWCOIN;
-        itemInfoMap.get("3114").itemValue = itemValue3114;
-        itemInfoMap.get("3113").itemValue = itemValue3113;
-        itemInfoMap.get("3112").itemValue = itemValue3112;
-        itemInfoMap.get("3303").itemValue = itemValue3303;
-        itemInfoMap.get("3302").itemValue = itemValue3302;
-        itemInfoMap.get("3301").itemValue = itemValue3301;
-        itemInfoMap.get("7001").itemValue = itemValue7001;
+        const chipIdList = ["3211", "3221", "3231", "3241", "3251", "3261", "3271", "3281"];
+        const chipPackIdList = ["3212", "3222", "3232", "3242", "3252", "3262", "3272", "3282"];
+        const dualChipIdList = ["3213", "3223", "3233", "3243", "3253", "3263", "3273", "3283"];
 
-        const chip1 = ['3211', '3221', '3231', '3241', '3251', '3261', '3271', '3281']
-        const chip2 = ['3212', '3222', '3232', '3242', '3252', '3262', '3272', '3282']
-        const chip3 = ['3213', '3223', '3233', '3243', '3253', '3263', '3273', '3283']
-
-        for (const chipId of chip1) {
-            itemInfoMap.get(chipId).itemValue = chip1Value;
+        for (const chipId of chipIdList) {
+            itemValueMap.set(chipId, chip1Value);
         }
-        for (const chipId of chip2) {
-            itemInfoMap.get(chipId).itemValue = chip2Value;
+        for (const chipId of chipPackIdList) {
+            itemValueMap.set(chipId, chip2Value);
         }
-        for (const chipId of chip3) {
-            itemInfoMap.get(chipId).itemValue = chip3Value;
+        for (const chipId of dualChipIdList) {
+            itemValueMap.set(chipId, chip3Value);
         }
-        // for (const [itemId, item] of itemInfoMap) {
-        //     console.log(itemId, item.itemName, item.itemValue)
-        // }
     }
 
 
     /**
-     * 获取加工站物品合成时的各级物品副产品期望产出
-     * @param itemList
-     * @private
+     * 检查是否满足停机条件
+     * 停机条件：对于每种未自定义价值的蓝材料，定价作战集中以该系列材料为主产物的最高效率作战的作战效率在 (1 - tolerance, 1 + tolerance) 之间。
+     * @returns {boolean} 是否满足停机条件
      */
-    function _getWorkShopProductValue(itemList) {
-
-        //根据星级分类
-        let collect = new Map()
-        //循环物品信息表
-        for (const item of itemList) {
-            //通过副产物排除非可加工物品
-            if (item.weight === 0) {
-                continue
-            }
-            //判断物品等级进行分类
-            if (!collect.get(item.rarity)) {
-                collect.set(item.rarity, [])
-            }
-
-            collect.get(item.rarity).push(item)
-        }
-
-        //计算按物品等级分类后的加工站各级物品副产品期望产出
-        for (const [rarity, group] of collect) {
-            let expectValue = 0.0
-            for (const item of group) {
-                const { itemValue, itemName, weight } = item
-                expectValue += itemValue * weight
-                // console.log('+=',itemName+'='+itemValue+'*'+weight,'=',expectValue)
-            }
-            //更新加工站各级物品副产品期望产出
-            workShopProducts[`t${rarity}`] = expectValue
-        }
+    function checkCompletion(tolerance) {
+        return ITEM_SERIES_INFO.every(({ seriesId }) => (
+            customEliteMaterialValueMap.has(seriesId)  // 已经自定义的蓝材料不需要检查
+            || Math.abs(maxStageEfficiencyMap.get(seriesId).stageEfficiency - 1) < tolerance
+        ));
     }
-
-}
-
-/**
- *  * 获取物品价值迭代系数
- * @param stageConfig 关卡配置
- * @returns {Promise<{nextItemCorrectionTerm: Map<any, any>}>}
- */
-async function getItemValueCorrectionTerm(stageConfig) {
-
-
-    //物品map
-    let itemMap = new Map()
-
-    //将物品信息集合转为一个物品信息map
-    for (const item of itemInfoList) {
-        itemMap.set(item.itemId, item)
-    }
-
-    //每个物品系列的最高效率关卡
-    let maxStageEfficiencyMap = new Map()
-    //虚拟SideStory关卡效率集合
-    let activityAverageStageEfficiency = new Map()
-
-    //循环关卡的物品掉落集合，每个集合是根据关卡id分组的
-    for (const [stageId, list] of stageDropCollect) {
-
-        //关卡消耗理智，关卡代号，关卡类型
-        const { apCost, stageCode, stageType } = list[0]
-
-        if (['MAIN', 'ACT_PERM'].includes(stageType)) {
-            //如果不使用活动关定价则跳出循环
-        }
-
-        if (['ACT', 'ACT_REP'].includes(stageType)) {
-            if (!stageConfig.useActivityStage) {
-                continue
-            }
-        }
-
-        if ('YTL_VIRTUAL' === stageType) {
-            if (!stageConfig.useActivityAverageStage) {
-                continue
-            }
-        }
-
-
-        //关卡效率
-        let stageEfficiency = 0.0
-        //关卡期望产出总理智
-        let stageExpectedOutput = 0.0
-
-        //如果是第一次迭代，需要给每个关卡的物品掉落添加一个龙门币掉落，
-        // if (index === 0) {
-        //     list.push({
-        //         stageId: stageId,
-        //         itemId: "4001",
-        //         quantity: apCost * 12,
-        //         times: 1
-        //     })
-        //     // 如果是活动再添加一个无限兑换龙门币，视为关卡掉落物
-        //     if ("ACT" === stageType || "ACT_REP" === stageType||"ACT_REP" === 'YTL_VIRTUAL') {
-        //         list.push({
-        //             stageId: stageId,
-        //             itemId: "4001",
-        //             quantity: apCost * 20,
-        //             times: 1
-        //         })
-        //     }
-        // }
-
-        //主产物物品id
-        let mainItemId = ''
-        //最高的单项物品产出价值
-        let maxValue = 0
-
-        let dropItemList = []
-
-        //循环关卡的物品掉落集合
-        for (const drop of list) {
-
-            //解构出物品id，掉落次数，样本数
-            const { itemId, quantity, times } = drop
-
-            // 从物品表里面取出对应掉落物的信息
-            const itemInfo = itemMap.get(itemId);
-
-            //如果查不到物品信息则跳过
-            if (!itemInfo) {
-                continue
-            }
-
-            //从物品信息中解构出物品价值
-            const { itemValue, itemName } = itemInfo;
-
-            //计算物品掉率
-            const knockRating = quantity / times
-
-            //计算单项物品期望产出价值
-            const expectedOutput = knockRating * itemValue
-
-            //比较单项物品最大产出，最大的为主产物
-            if (expectedOutput > maxValue) {
-                mainItemId = itemId
-                maxValue = expectedOutput
-            }
-
-            // if(stageId==='main_12-15'){
-            //     // console.log(stageCode, '---', itemName, '=', itemValue, '*', knockRating, '=', expectedOutput, '=', dropValueCount)
-            //     dropItemList.push({
-            //         itemId,
-            //         itemName,
-            //         knockRating,
-            //         itemValue
-            //     })
-            // }
-
-            //计算关卡期望产出总理智
-            stageExpectedOutput += expectedOutput
-        }
-
-        // console.log(JSON.stringify(dropItemList))
-
-        //计算关卡效率
-        stageEfficiency = stageExpectedOutput / apCost
-        // if (stageId === 'main_02-05') {
-        //     console.log(stageCode, '---', stageEfficiency, '=', dropValueCount, '/', apCost)
-        // }
-
-
-        //查询这个关卡的主产物是否是精英物品
-        if (!itemSeriesInfoByItemId.has(mainItemId)) {
-            // console.log(mainItemId,'不在18种物品中')
-            continue
-        }
-
-        //获取精英物品对应系列的信息  如凝胶系为[凝胶、聚合凝胶]
-        let seriesInfo = itemSeriesInfoByItemId.get(mainItemId)
-
-        //物品系列的id和名称
-        const { seriesId, seriesName } = seriesInfo
-
-        //物品系列的迭代值
-        const seriesCorrectionTerm = {
-            stageCode: stageCode,
-            seriesId: seriesId,
-            seriesName: seriesName,
-            correctionTerm: stageEfficiency,
-        }
-
-        // nextStageDropCollect.set(stageId, list)
-
-        // //如果关卡系列为
-        // if (stageType === 'YTL_VIRTUAL') {
-        //     activityAverageStageEfficiency.set(seriesId, seriesCorrectionTerm)
-        // }
-
-
-        //判断是否有对应精英物品系列的迭代值
-        if (maxStageEfficiencyMap.has(seriesId)) {
-
-            //获取当前物品系列的迭代值
-            const correctionTerm = maxStageEfficiencyMap.get(seriesId).correctionTerm
-
-            //判断迭代值是否和已有的迭代值大小，如果更大则更新
-            if (stageEfficiency > correctionTerm) {
-                maxStageEfficiencyMap.set(seriesId, seriesCorrectionTerm)
-            }
-        } else {
-            //没有对应物品系列迭代值新增
-            maxStageEfficiencyMap.set(seriesId, seriesCorrectionTerm)
-        }
-    }
-
-    // //如果自定义关卡配置将虚拟关卡作为定价关，重新再判断一次定价关
-    // if (stageConfig.useActivityAverageStage) {
-    //
-    //     for (const [seriesId, seriesCorrectionTerm] of activityAverageStageEfficiency) {
-    //
-    //         //获取当前物品系列的迭代值
-    //         const correctionTerm = maxStageEfficiencyMap.get(seriesId).correctionTerm
-    //
-    //         // if (!('31053' === seriesId || '31033' === seriesId)) {
-    //         //     maxStageEfficiencyMap.set(seriesId, seriesCorrectionTerm)
-    //         // }
-    //
-    //         if (seriesCorrectionTerm.correctionTerm > correctionTerm) {
-    //             maxStageEfficiencyMap.set(seriesId, seriesCorrectionTerm)
-    //         }
-    //     }
-    // }
-
-
-    return {
-        nextItemCorrectionTerm: maxStageEfficiencyMap
-    }
-
-}
-
-/**
- * 根据关卡自定义参数获取自定义材料价值表
- * @param stageConfig 关卡自定义参数
- * @return {Promise<*>}
- */
-async function getCustomItemList(stageConfig) {
-
-    //获取根据关卡id分类的关卡掉落数据
-    stageDropCollect = await getStageDropCollect(stageConfig, true)
-
-    const customItem = stageConfig.customItem
-
-    //自定义物品map
-    let customItemMap = new Map()
-
-    //将自定义物品列表转为一个map
-    if (customItem) {
-        for (const item of customItem) {
-            const { itemId, itemValue } = item
-            customItemMap.set(itemId, itemValue)
-        }
-    }
-
-
-    //迭代物品价值，一般10次之内就能得出结果
-    for (let i = 0; i < 50; i++) {
-        // console.log(`第${i + 1}次迭代1`)
-        // console.table(itemList)
-        calculatedItemValue(stageConfig)
-
-        const { nextItemCorrectionTerm } = await getItemValueCorrectionTerm(stageConfig);
-
-        //是否迭代完成的标记
-        let completionFlag = true;
-
-        for (const [seriesId, item] of nextItemCorrectionTerm) {
-            itemValueCorrectionTerm[seriesId].correctionTerm = item.correctionTerm
-
-            //判断每个物品系列的最优关卡的理智转化率是否与1的误差小于0.0001
-            if (!customItemMap.get(seriesId)) {
-                // console.log(item.seriesName, '————', item.stageCode, '————', item.correctionTerm, '————', Math.abs(1 - item.correctionTerm))
-                completionFlag = completionFlag && Math.abs(1 - item.correctionTerm) < 0.0001
-            }
-        }
-
-        //如果上面的误差均小于0.0001，结束迭代
-        if (completionFlag) {
-            console.log(`第${i + 1}次迭代完成`)
-            break;
-        }
-
-
-    }
-
-    // console.log("物品价值：",itemList)
-
-    return itemInfoList
 }
 
 
-export {
-    getCustomItemList
-};
+export { getCustomItemList };

--- a/src/utils/item/stageEfficiencyCal.js
+++ b/src/utils/item/stageEfficiencyCal.js
@@ -28,7 +28,7 @@ async function calculationStageEfficiency(stageConfig) {
     const start = new Date().getTime()
 
     const itemMap = await getItemMap(stageConfig)
-    const stageDropCollect = await getStageDropCollect(stageConfig)
+    const stageDropCollect = await getStageDropCollect(stageConfig)  // TODO: getStageDropCollect 有 2 个参数
     const loading = new Date().getTime()
     // console.log("加载数据", loading - start, 'ms')
 

--- a/src/utils/user/userConfig.js
+++ b/src/utils/user/userConfig.js
@@ -1,65 +1,275 @@
-import {ref} from "vue";
-import {stringToNumber} from '/src/utils/stringUtils.js'
-import {getUid} from "@/utils/user/userInfo.js";
+import { getUid } from "@/utils/user/userInfo.js";
+import { ref } from "vue";
 
+// 预设项
+
+/**
+ * 合成玉价值
+ */
+const orundumValueMap = {
+    'ORUNDUM_PRICING_ORIGINITE_PRIME': 0.75,
+    'ORUNDUM_PRICING_ORININUM_FARMING_ORIROCK_CUBE': null,
+    'ORUNDUM_PRICING_ORININUM_FARMING_DEVICE': null,
+    'ORUNDUM_PRICING_INFINITY': Infinity,
+    'ORUNDUM_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 至纯源石价值系数
+ */
+const originitePrimeCoefficientMap = {
+    'ORIGINITE_PRIME_PRICING_ORUNDUM': 180,
+    'ORIGINITE_PRIME_PRICING_INFINITY': Infinity,
+    'ORIGINITE_PRIME_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 中坚寻访凭证价值系数
+ */
+const kernalHeadhuntingPermitCoefficientMap = {
+    'KERNAL_HEADHUNTING_PERMIT_PRICING_DISTINCTION_CERTIFICATE': 216 / 258,
+    'KERNAL_HEADHUNTING_PERMIT_PRICING_ZERO': 0,
+    'KERNAL_HEADHUNTING_PERMIT_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 龙门币价值系数
+ */
+const lmdCoefficientMap = {
+    'LMD_PRICING_CE-6': 1,
+    'LMD_PRICING_ZERO': 0,
+    'LMD_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * EXP 价值系数
+ */
+const expCoefficientMap = {
+    'EXP_PRICING_LS-6': 598 / 625, // 0.9568
+    'EXP_PRICING_ZERO': 0,
+    'EXP_PRICING_BASE_LVL_3_TP': 145 / 229,  // 0.6332
+    'EXP_PRICING_BASE_LVL_3_TP_TEQUILA_2_PROVISO_2': 235 / 293,  // 0.8020
+    'EXP_PRICING_BASE_LVL_2_TP_PROVISO_2': 165 / 203,  // 0.8128
+    'EXP_PRICING_BASE_LVL_1_TP_PROVISO_2': 5 / 6,  // 0.8333
+    'EXP_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 模组数据块价值
+ */
+const modUnlockTokenValueMap = {
+    'MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE': null,
+    'MOD_UNLOCK_TOKEN_PRICING_DISTINCTION_CERTIFICATE': null,
+    'MOD_UNLOCK_TOKEN_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 招聘许可价值
+ */
+const recruitmentPermitValueMap = {
+    'RECRUITMENT_PERMIT_PRICING_3_4': null,
+    'RECRUITMENT_PERMIT_PRICING_3_4_5': null,
+    'RECRUITMENT_PERMIT_PRICING_3_4_5_6': null,
+    'RECRUITMENT_PERMIT_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 加急许可价值
+ */
+const expeditedPlanValueMap = {
+    'EXPEDITED_PLAN_PRICING_ZERO': 0,
+    'EXPEDITED_PLAN_PRICING_RECRUITMENT_PERMIT': null,
+    'EXPEDITED_PLAN_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 家具零件价值
+ */
+const furniturePartValueMap = {
+    'FURNITURE_PART_PRICING_ZERO': 0,
+    'FURNITURE_PART_PRICING_SK-5': null,
+    'FURNITURE_PART_PRICING_CUSTOM': undefined,
+};
+
+/**
+ * 默认用户配置
+ */
 const defaultConfig = {
-    id: getUid(),
-    expCoefficient: 0.633,
-    lmdCoefficient: 1,
+    source: 'penguin',
+
+    // 定价作战集
     useActivityStage: false,
     useActivityAverageStage: false,
+    sampleSize: 300,
     stageBlacklist: [],
-    source: 'penguin',
-    workshopEliteMaterialByProductRate: 0.2,
-    workshopSkillSummaryByProductRate: 0.18,
+    stageWhitelist: [],  // 关卡白名单，该配置暂未实现
+
+
+    // 自定义其他物品价值
+    orundumPricingStrategy: "ORUNDUM_PRICING_ORIGINITE_PRIME",  // 合成玉定价策略
+    orundumValue: 3 / 4,  // 合成玉价值
+
+    originitePrimePricingStrategy: "ORIGINITE_PRIME_PRICING_ORUNDUM",  // 至纯源石定价策略
+    originitePrimeCoefficient: 180,  // 至纯源石价值系数
+
+    kernalHeadhuntingPermitPricingStrategy: "KERNAL_HEADHUNTING_PERMIT_PRICING_DISTINCTION_CERTIFICATE",  // 中坚寻访凭证定价策略
+    kernalHeadhuntingPermitCoefficient: 216 / 258,  // 中坚寻访凭证价值系数
+
+    lmdPricingStrategy: "LMD_PRICING_CE-6",  // 龙门币定价策略
+    lmdCoefficient: 1,  // 龙门币价值系数
+
+    expPricingStrategy: "EXP_PRICING_BASE_LVL_3_TP",  // EXP 定价策略
+    expCoefficient: 145 / 229,  // EXP 价值系数
+
+    modUnlockTokenPricingStrategy: "MOD_UNLOCK_TOKEN_PRICING_PURCHASE_CERTIFICATE",  // 模组数据块定价策略
+    modUnlockTokenValue: 120 * 30 / 21,  // 模组数据块价值
+
+    recruitmentPermitPricingStrategy: "RECRUITMENT_PERMIT_PRICING_3_4",  // 招聘许可定价策略
+    recruitmentPermitValue: null,  // 招聘许可价值
+
+    expeditedPlanPricingStrategy: "EXPEDITED_PLAN_PRICING_ZERO",  // 加急许可定价策略
+    expeditedPlanValue: 0,  // 加急许可价值
+
+    furniturePartPricingStrategy: "FURNITURE_PART_PRICING_ZERO",  // 家具零件定价策略
+    furniturePartValue: 0,  // 家具零件价值
+
+    // 自定义精英材料价值
     customItem: [
         {
-            itemId: '30073',
-            itemName: "扭转醇",
-            itemValue: 1.8
+            itemId: "30073",  // 轻锰矿
+            itemValue: 1.8,
         },
         {
-            itemId: '30083',
-            itemName: "轻锰矿",
-            itemValue: 2.16
-        }
-    ]
+            itemId: "30083",  // 扭转醇
+            itemValue: 2.16,
+        },
+    ],
+
+    workshopEliteMaterialByProductRate: 0.2,  // 待弃用的配置项
+    workshopSkillSummaryByProductRate: 0.18,  // 待弃用的配置项
+
+    // TODO: 加工站副产品策略，该配置暂未实现
+    workshopStrategy: {
+        eliteMaterialT1toT2: {
+            strategy: "WORKSHOP_STRATEGY_NCDEER",
+            byproductRateIncreasement: null,
+        },
+        eliteMaterialT2toT3: {
+            strategy: "WORKSHOP_STRATEGY_NCDEER",
+            byproductRateIncreasement: null,
+        },
+        eliteMaterialT3toT4: {
+            strategy: "WORKSHOP_STRATEGY_COMMON",
+            byproductRateIncreasement: 1,
+        },
+        eliteMaterialT4toT5: {
+            strategy: "WORKSHOP_STRATEGY_COMMON",
+            byproductRateIncreasement: 1,
+        },
+        skillSummary1to2: {
+            strategy: "WORKSHOP_STRATEGY_NCDEER",
+            byproductRateIncreasement: null,
+        },
+        skillSummary2to3: {
+            strategy: "WORKSHOP_STRATEGY_NCDEER",
+            byproductRateIncreasement: null,
+        },
+        // TODO: 芯片策略暂未实现（因为芯片组用九色鹿是赚的，还需要思考细节）
+        // chipStrategy: {
+        //     strategy: "WORKSHOP_STRATEGY_NCDEER",
+        //     byproductRateIncreasement: null,
+        // },
+        // chipPackStrategy: {
+        //     strategy: "WORKSHOP_STRATEGY_NCDEER",
+        //     byproductRateIncreasement: null,
+        // },
+        baseMaterial: {
+            strategy: "WORKSHOP_STRATEGY_NCDEER",
+            byproductRateIncreasement: null,
+        },
+    },
+
+    chipPreference: {
+        TANK_MEDIC: "BALANCED",
+        SNIPER_CASTER: "BALANCED",
+        PIONEER_SUPPORT: "BALANCED",
+        WARRIOR_SPECIAL: "BALANCED",
+    },
+};
+
+
+/**
+ * 反序列化配置
+ * 解析时会将字符串 `"Infinity"`、`"-Infinity"` 和 `"NaN"` 转换为对应的数值。
+ * @param {string} configString
+ * @returns {Object} 解析后的配置对象
+ */
+function parseConfig(configString) {
+    return JSON.parse(
+        configString,
+        (key, value) => {
+            // 如果是字符串，尝试转换为数字
+            switch (value) {
+                case "Infinity":
+                    return Infinity;
+                case "-Infinity":
+                    return -Infinity;
+                case "NaN":
+                    return NaN;
+                default:
+                    return value;
+            }
+        },
+    );
 }
 
+/**
+ * 序列化配置
+ * 序列化时会将 `Infinity`、`-Infinity` 和 `NaN` 转换为对应的字符串。
+ * @param {Object} config
+ * @returns {string} 序列化后的配置
+ */
+function stringifyConfig(config) {
+    return JSON.stringify(
+        config,
+        (key, value) => {
+            switch (value) {
+                case Infinity:
+                    return "Infinity"; // 将 Infinity 转换为字符串
+                case -Infinity:
+                    return "-Infinity"; // 将 -Infinity 转换为字符串
+                case NaN:
+                    return "NaN"; // 将 NaN 转换为字符串
+                default:
+                    return value; // 其他值保持不变
+            }
+        },
+        2,
+    );
+}
 
-
-
-let stageConfig = ref(defaultConfig)
+// 冒充一下 deepcopy
+let stageConfig = ref(parseConfig(stringifyConfig(defaultConfig)));
 
 /**
  * 获取关卡配置
- * @returns {any | {
- *     id: number,
- *     expCoefficient: number,
- *     lmdCoefficient: number,
- *     useActivityStage: boolean,
- *     stageBlacklist: *[],
- *     source: string,
- *     workshopEliteMaterialByProductRate: number,
- *     workshopSkillSummaryByProductRate: number,
- *     customItem: [{itemId: string, itemName: string, itemValue: number}]
- * }}
- */
+ * @returns {Object} 用户配置
+*/
 function getStageConfig() {
     const cacheStageConfig = localStorage.getItem("StageConfig");
     if (cacheStageConfig) {
-        let config = JSON.parse(cacheStageConfig);
-        if(!config.customItem){
-            config.customItem = []
+        let config = parseConfig(cacheStageConfig);
+        if (!config.customItem) {
+            config.customItem = [];
         }
 
-        for(const key in config) {
+        for (const key in config) {
             stageConfig.value[key] = config[key];
         }
 
         return stageConfig.value;
     } else {
-        return defaultConfig
+        return defaultConfig;
     }
 }
 
@@ -87,5 +297,18 @@ function getStageConfig() {
 // config.customItem = list
 
 export {
-    getStageConfig, stageConfig,defaultConfig
-}
+    defaultConfig,
+    stageConfig,
+    getStageConfig,
+    parseConfig,
+    stringifyConfig,
+    orundumValueMap,
+    originitePrimeCoefficientMap,
+    kernalHeadhuntingPermitCoefficientMap,
+    lmdCoefficientMap,
+    expCoefficientMap,
+    modUnlockTokenValueMap,
+    recruitmentPermitValueMap,
+    expeditedPlanValueMap,
+    furniturePartValueMap
+};


### PR DESCRIPTION
- 自定义非精英材料定价策略
- 添加物品”加急许可“
- 删除物品"合成玉(搓玉)"
- 更改自定义物品价值参数的快速设置预设项
- 信用交易所性价比添加家具零件和加急许可
- 重构物品价值算法

需要一个加急许可的物品图片