### PR TITLE
feat:固定“练度数据导出”为实装倒序，时间相同按星级降序

### DIFF
--- a/src/pages/survey/operator.vue
+++ b/src/pages/survey/operator.vue
@@ -444,7 +444,11 @@ function exportOperatorExcel() {
     '干员名称', '是否已招募', '星级', '等级', '精英化等级', '潜能等级', '通用技能等级', '1技能专精等级',
     '2技能专精等级', '3技能专精等级', 'χ分支模组', 'γ分支模组', 'Δ分支模组', 'α分支模组'
   ]]
-  for (const operator of operatorList.value) {
+  //按实装倒序排序，时间相同时按星级降序排序
+  const sortedOperatorList = [...operatorList.value].sort((a, b) =>
+    b.updateTime - a.updateTime || b.rarity - a.rarity
+  )
+  for (const operator of sortedOperatorList) {
     const {name,own,rarity,level,elite,potential,mainSkill,skill1,skill2,skill3,modX,modY,modD,modA} = operator
     list.push([name,own,rarity,level,elite,potential,mainSkill,skill1,skill2,skill3,modX,modY,modD,modA])
   }


### PR DESCRIPTION
- Sort without changing `operatorList`
- Before <img width="300" height="748" alt="test_before" src="https://github.com/user-attachments/assets/90a2464e-da4d-463f-871a-eb9b214a57f0" />
- After <img width="330" height="753" alt="test_after" src="https://github.com/user-attachments/assets/e8dd582b-e075-4da3-ae8a-ef94ffdb53e7" />

closes #174 